### PR TITLE
Fix memory corruption in cl::Program::getInfo<CL_PROGRAM_BINARIES>()

### DIFF
--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -940,14 +940,12 @@ inline cl_int getInfoHelper(Func f, cl_uint name, vector<vector<unsigned char>>*
         size_type numBinaries = param->size();
         vector<unsigned char*> binariesPointers(numBinaries);
 
-        size_type totalSize = 0;
         for (size_type i = 0; i < numBinaries; ++i)
         {
             binariesPointers[i] = (*param)[i].data();
-            totalSize += (*param)[i].size();
         }
 
-        cl_int err = f(name, totalSize, binariesPointers.data(), NULL);
+        cl_int err = f(name, numBinaries * sizeof(unsigned char*), binariesPointers.data(), NULL);
 
         if (err != CL_SUCCESS) {
             return err;


### PR DESCRIPTION
This fixes memory corruption in `cl::Program::getInfo<CL_PROGRAM_BINARIES>()` function. The problem may be observed with the following test program. It crashes without the patch for AMD W9100 GPU, but strangely, works with NVIDIA CUDA platform (Tesla K40c).
```cpp
#include <iostream>
#include <vector>
#include <string>

#define CL_HPP_ENABLE_EXCEPTIONS
#include <CL/cl2.hpp>

int main() {
    // Get list of OpenCL platforms.
    std::vector<cl::Platform> platform;
    cl::Platform::get(&platform);

    if (platform.empty())
        throw std::runtime_error("No OpenCL platforms");

    // Get the Hawaii GPU.
    cl::Context context;
    std::vector<cl::Device> device;
    for(auto p = platform.begin(); device.empty() && p != platform.end(); p++) {
        std::vector<cl::Device> pldev;
        try {
            p->getDevices(CL_DEVICE_TYPE_GPU, &pldev);
            for(auto d = pldev.begin(); device.empty() && d != pldev.end(); d++) {
                if (!d->getInfo<CL_DEVICE_NAME>() != "Hawaii") continue;
                device.push_back(*d);
                context = cl::Context(device);
            }
        } catch(...) {
            device.clear();
        }
    }
    if (device.empty()) throw std::runtime_error("No GPUs");

    // Compile OpenCL program for the device.
    cl::Program program(context, std::string(R"(
                kernel void add(
                  ulong n,
                  global const float *a,
                  global const float *b,
                  global float *c
                  )
                {
                  ulong i = get_global_id(0);
                  if (i < n) c[i] = a[i] + b[i];
                })"));
    try {
        program.build(device);
    } catch (const cl::Error&) {
        std::cerr
            << "OpenCL compilation error" << std::endl
            << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device[0])
            << std::endl;
        throw std::runtime_error("OpenCL build error");
    }

    // Without the patch, the following results in memory corruption, followed by crash on destruction
    // of binariesPointers vector.
    std::vector<std::vector<unsigned char>> binaries = program.getInfo<CL_PROGRAM_BINARIES>();
}
```