### PR TITLE
Added 8 missing Get<> 1.2 specializations  + 1 return type fix

### DIFF
--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -1421,7 +1421,6 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
 #if defined(CL_VERSION_1_1)
 #define __PARAM_NAME_INFO_1_1(F) \
     F(cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)\
-    \
     F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint) \
@@ -1468,7 +1467,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, ::size_t) \
     F(cl_device_info, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, ::size_t) \
     F(cl_device_info, CL_DEVICE_LINKER_AVAILABLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS)\
+    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS) \
     F(cl_device_info, CL_DEVICE_PRINTF_BUFFER_SIZE, ::size_t) \
     F(cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, cl_bool) \
     F(cl_device_info, CL_DEVICE_PARENT_DEVICE, cl_device_id) \
@@ -1476,7 +1475,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, VECTOR_CLASS<cl_device_partition_property>) \
     F(cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain) \
     F(cl_device_info, CL_DEVICE_PARTITION_TYPE, VECTOR_CLASS<cl_device_partition_property>)  \
-    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint) \
+    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint)
 #endif // #if defined(CL_VERSION_1_2)
 
 #if defined(USE_CL_DEVICE_FISSION)

--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -1421,6 +1421,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
 #if defined(CL_VERSION_1_1)
 #define __PARAM_NAME_INFO_1_1(F) \
     F(cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)\
+    \
     F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint) \
@@ -1446,7 +1447,10 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     
 #if defined(CL_VERSION_1_2)
 #define __PARAM_NAME_INFO_1_2(F) \
+    F(cl_image_info, CL_IMAGE_ARRAY_SIZE, ::size_t) \
     F(cl_image_info, CL_IMAGE_BUFFER, cl::Buffer) \
+    F(cl_image_info, CL_IMAGE_NUM_MIP_LEVELS, cl_uint) \
+    F(cl_image_info, CL_IMAGE_NUM_SAMPLES, cl_uint) \
     \
     F(cl_program_info, CL_PROGRAM_NUM_KERNELS, ::size_t) \
     F(cl_program_info, CL_PROGRAM_KERNEL_NAMES, STRING_CLASS) \
@@ -1458,16 +1462,21 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_kernel_arg_info, CL_KERNEL_ARG_ADDRESS_QUALIFIER, cl_kernel_arg_address_qualifier) \
     F(cl_kernel_arg_info, CL_KERNEL_ARG_ACCESS_QUALIFIER, cl_kernel_arg_access_qualifier) \
     F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_NAME, STRING_CLASS) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_NAME, STRING_CLASS) \
     F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_QUALIFIER, cl_kernel_arg_type_qualifier) \
+    F(cl_kernel_arg_info, CL_KERNEL_ARG_NAME, STRING_CLASS) \
     \
+    F(cl_device_info, CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, ::size_t) \
+    F(cl_device_info, CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, ::size_t) \
+    F(cl_device_info, CL_DEVICE_LINKER_AVAILABLE, cl_bool) \
+    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS)\
+    F(cl_device_info, CL_DEVICE_PRINTF_BUFFER_SIZE, ::size_t) \
+    F(cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, cl_bool) \
     F(cl_device_info, CL_DEVICE_PARENT_DEVICE, cl_device_id) \
+    F(cl_device_info, CL_DEVICE_PARTITION_MAX_SUB_DEVICES, cl_uint) \
     F(cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, VECTOR_CLASS<cl_device_partition_property>) \
+    F(cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain) \
     F(cl_device_info, CL_DEVICE_PARTITION_TYPE, VECTOR_CLASS<cl_device_partition_property>)  \
     F(cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, ::size_t) \
-    F(cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain) \
-    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS)
 #endif // #if defined(CL_VERSION_1_2)
 
 #if defined(USE_CL_DEVICE_FISSION)


### PR DESCRIPTION
I'm putting these fixes out but I would like to address a bigger problem:

As I was making these fixes, I noticed that these missing enums added in CL 1.2 were not present in the OpenCL 1.2 C++ Wrapper spec, which might explain why there are missing from the cl.hpp headers.

The thing is: the spec is not technically incorrect because it only includes the "values that differ in return type between the OpenCL C API and the OpenCL C++ API" and only refers to the OpenCL C spec for the ones that don't need special C++ types like string and vectors instead of C pointers.

As all the 8 missing enums had primitive return types, I guess that what happened is that the person/s who updated the cl.hpp missed that subtlety and only added in the header the values that were added in the CL 1.2 C++ spec tables, and thus missed these 8 ones.

Anyways, I don't think it can merged as-is because:
- I didn't updated the cl2.hpp which might require special care since some of those might have been deprecated in 2.0, 2.1 or 2.2.
-  I didn't run the tests due to non-installed dependencies (even though the changes are trivial).
