### PR TITLE
Add install target for CL headers

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_command(
     COMMAND python ${CLCPP_SOURCE_DIR}/gen_cl_hpp.py -i ${CLCPP_SOURCE_DIR}/input_cl.hpp -o ${CMAKE_CURRENT_BINARY_DIR}/CL/cl.hpp
     DEPENDS ${CLCPP_SOURCE_DIR}/input_cl.hpp ${CLCPP_SOURCE_DIR}/gen_cl_hpp.py
     COMMENT "Rebuilding cl.hpp ...")
-add_custom_target(generate_clhpp DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CL/cl.hpp SOURCES ${CLCPP_SOURCE_DIR}/input_cl.hpp)
+add_custom_target(generate_clhpp ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CL/cl.hpp SOURCES ${CLCPP_SOURCE_DIR}/input_cl.hpp)
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CL/cl2.hpp
@@ -12,4 +12,10 @@ add_custom_command(
     COMMAND cp ${CLCPP_SOURCE_DIR}/input_cl2.hpp ${CMAKE_CURRENT_BINARY_DIR}/CL/cl2.hpp
     DEPENDS ${CLCPP_SOURCE_DIR}/input_cl2.hpp
     COMMENT "Rebuilding cl2.hpp ...")
-add_custom_target(generate_cl2hpp DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CL/cl2.hpp SOURCES ${CLCPP_SOURCE_DIR}/input_cl2.hpp)
+add_custom_target(generate_cl2hpp ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CL/cl2.hpp SOURCES ${CLCPP_SOURCE_DIR}/input_cl2.hpp)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CL
+        DESTINATION .
+        FILES_MATCHING
+        PATTERN "*.hpp"
+        )

--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -1578,6 +1578,7 @@ struct ReferenceHandler<cl_event>
 };
 
 
+#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
 // Extracts version number with major in the upper 16 bits, minor in the lower 16
 static cl_uint getVersion(const vector<char> &versionInfo)
 {
@@ -1598,12 +1599,11 @@ static cl_uint getVersion(const vector<char> &versionInfo)
     return (highVersion << 16) | lowVersion;
 }
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
 static cl_uint getPlatformVersion(cl_platform_id platform)
 {
     size_type size = 0;
     clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, NULL, &size);
-    
+
     vector<char> versionInfo(size);
     clGetPlatformInfo(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
     return getVersion(versionInfo);


### PR DESCRIPTION
This may not be absolutely needed change but having the headers at specified location rather than at cmake-generated path is more useful for down stream projects.

Default `CMAKE_INSTALL_PREFIX` is `/usr/include` on linux, thus resulting in appropriate installation of  `CL/*` files to `/usr/include` path.