### PR TITLE
Fix redundant Wrapper::get()

### DIFF
--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -1699,10 +1699,7 @@ public:
 
     cl_type& operator ()() { return object_; }
 
-    const cl_type get() const { return object_; }
-
-    cl_type get() { return object_; }
-
+    cl_type get() const { return object_; }
 
 protected:
     template<typename Func, typename U>


### PR DESCRIPTION
When returning cl_type by value do not add additional const modifier. This fixes GCC warning "type qualifiers ignored on function return type".