### PR TITLE
Fixed version of PR31

### DIFF
--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -1828,9 +1828,7 @@ public:
 
     cl_type& operator ()() { return object_; }
 
-    const cl_type get() const { return object_; }
-
-    cl_type get() { return object_; }
+    cl_type get() const { return object_; }
 
 protected:
     template<typename Func, typename U>


### PR DESCRIPTION
@chfast Never showed back up in https://github.com/KhronosGroup/OpenCL-CLHPP/pull/31

This modifies only the cl_device_id version of wrapper.
