### PR TITLE
Fix NULL Terminator in string class

### DIFF
--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -1233,15 +1233,20 @@ inline cl_int getInfoHelper(Func f, cl_uint name, STRING_CLASS* param, long)
         return err;
     }
 
-    // std::string has a constant data member
-    // a char vector does not
-    VECTOR_CLASS<char> value(required);
-    err = f(name, required, value.data(), NULL);
-    if (err != CL_SUCCESS) {
-        return err;
+    if (required > 0) {
+        // std::string has a constant data member
+        // a char vector does not
+        VECTOR_CLASS<char> value(required);
+        err = f(name, required, value.data(), NULL);
+        if (err != CL_SUCCESS) {
+            return err;
+        }
+        if (param) {
+            param->assign(value.begin(), value.end() - 1u);
+        }
     }
-    if (param) {
-        param->assign(value.begin(), value.end());
+    else if (param) {
+        param->assign("");
     }
 #endif
     return CL_SUCCESS;


### PR DESCRIPTION
Fixes #8
Backport of 8e9aebb (No NULL byte) and c43a7ed (Return empty string)

Similar to PR #12 but fixes only the bug. Uses a backport of the cl2.hpp header fix suggested by @jrprice 

CCing @coleb