### PR TITLE
Fix catch of non-polymorphic cl::Error, fix uninitialized error value

### DIFF
--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -2742,7 +2742,9 @@ public:
                     error = platforms[i].getDevices(type, &devices);
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-                } catch (Error) {}
+                } catch (cl::Error& e) {
+                    error = e.err();
+                }
     // Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
     // We do error checking next anyway, and can throw there if needed
 #endif


### PR DESCRIPTION
Newest version of gcc warned about the non-polymorphic catch. I also noticed that error is never set if the exception is caught (because the throw happens before the assign).