### PR TITLE
Fix Issues when targeting OpenCL 1.1 or 1.0

### DIFF
--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -1337,6 +1337,8 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint) \
     F(cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint) \
     F(cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config) \
+    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
+    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type) \
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)\
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong) \
@@ -1434,8 +1436,6 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
     F(cl_device_info, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_bool) \
     F(cl_device_info, CL_DEVICE_OPENCL_C_VERSION, STRING_CLASS) \
     \
@@ -5765,6 +5765,7 @@ public:
 
         return err;
     }
+#if defined(CL_VERSION_1_1)
 
     cl_int enqueueReadBufferRect(
         const Buffer& buffer,
@@ -5880,6 +5881,7 @@ public:
 
         return err;
     }
+#endif //if defined(CL_VERSION_1_1)
 
 #if defined(CL_VERSION_1_2)
     /**

--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -1139,6 +1139,8 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint) \
     F(cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint) \
     F(cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config) \
+    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
+    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type) \
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)\
     F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong) \
@@ -1235,8 +1237,6 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint) \
     F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
     F(cl_device_info, CL_DEVICE_OPENCL_C_VERSION, string) \
     \
     F(cl_mem_info, CL_MEM_ASSOCIATED_MEMOBJECT, cl::Memory) \
@@ -7207,7 +7207,7 @@ public:
 
         return err;
     }
-
+#if CL_HPP_TARGET_OPENCL_VERSION >= 110
     cl_int enqueueReadBufferRect(
         const Buffer& buffer,
         cl_bool blocking,
@@ -7322,7 +7322,7 @@ public:
 
         return err;
     }
-
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
     /**
      * Enqueue a command to fill a buffer object with a pattern


### PR DESCRIPTION
The commit fixes 2 issues.
1) When targeting **OpenCL 1.0** the compiler throws an error for `enqueueReadBufferRect` saying it hasn't been declared in scope. This is because `enqueueXBufferRect` calls have been introduced from  
 **OpenCL 1.1**. The commit fixes this by adding a version check for these calls.

2) When targeting **OpenCL 1.1**  the compiler throws an error regarding `CL_DEVICE_DOUBLE_FP_CONFIG`. For detailed description of this issue, see: https://github.com/KhronosGroup/OpenCL-CLHPP/issues/48



This issue arises due to missing ` #defines` in OpenCL-C headers namely `cl.h` and `cl_ext.h`. Briefly describing, the macro `CL_DEVICE_DOUBLE_FP_CONFIG` is missing from `cl_ext.h` and only defined for **OpenCL 1.2 or greater** in `cl.h`.
  
Whereas both `CL_DEVICE_DOUBLE_FP_CONFIG` and `CL_DEVICE_HALF_FP_CONFIG` should be available at all OpenCL versions. 

This issue #48 is fixed by the following pending pull request to "OpenCL-Headers" registry

https://github.com/KhronosGroup/OpenCL-Headers/pull/28

However both `cl.hpp` and `cl2.hpp` define this parameter name from **OpenCL 1.1** onwards. This means it is still not available for OpenCL 1.0 when using the C++ bindings header. 

The commit fixes this 2nd issue by removing both parameter names `DOUBLE/HALF_FP_CONFIG`  from `PARAM_NAME_INFO_1_1` and adding them under `PARAM_NAME_INFO_1_0`

