### PR TITLE
Add notices for cl.hpp deprecation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,9 +6,10 @@ Doxgen documentation for the cl2.hpp header is available here:
 
 
 Components:
-  input_cl.hpp:
+  input_cl.hpp (DEPRECATED):
     Acts as the master source for the 1.x version of the header.
     The reason for doing it this way is to generate an appropriate set of functors with varying argument counts without assuming variadic template support in the header.
+    This version of the C++ bindings is deprecated and is no longer maintained; it is strongly recommended to switch to cl2.hpp if possible.
 
   input_cl2.hpp:
     Acts as the master source for the 2.x version of the header.

--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -150,6 +150,10 @@
 #ifndef CL_HPP_
 #define CL_HPP_
 
+// The latest version of the OpenCL C++ bindings can be found on GitHub:
+// -> https://github.com/KhronosGroup/OpenCL-CLHPP
+#pragma message("This version of the OpenCL Host API C++ bindings is deprecated, please use cl2.hpp instead.")
+
 #ifdef _WIN32
 
 #include <malloc.h>


### PR DESCRIPTION
The OpenCL WG have previously agreed that we wish to deprecate the older `cl.hpp` header in favour of `cl2.hpp`, which also supports OpenCL 1.x.

This relates to #25. The one outstanding niggle here is that the name of the newer header is a little misleading, and suggests that it only supports OpenCL 2.x.