### PR TITLE
input_cl: fix GCC warning

### DIFF
--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -2606,7 +2606,7 @@ public:
                     error = platforms[i].getDevices(type, &devices);
 
 #if defined(__CL_ENABLE_EXCEPTIONS)
-                } catch (Error) {}
+                } catch (Error &) {}
     // Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
     // We do error checking next anyway, and can throw there if needed
 #endif


### PR DESCRIPTION
Currently with -Wall, GCC is throwing the following warning:

warning: catching polymorphic type ‘class cl::Error’ by value
[-Wcatch-value=]. Fix this by catching by reference instead.