### PR TITLE
Catch exceptions by reference

### DIFF
--- a/input_cl2.hpp
+++ b/input_cl2.hpp
@@ -3725,7 +3725,7 @@ cl::pointer<T, detail::Deleter<Alloc>> allocate_pointer(const Alloc &alloc_, Arg
 
         return cl::pointer<T, detail::Deleter<Alloc>>(tmp, detail::Deleter<Alloc>{alloc, copies});
     }
-    catch (std::bad_alloc b)
+    catch (std::bad_alloc& b)
     {
         std::allocator_traits<Alloc>::deallocate(alloc, tmp, copies);
         throw;


### PR DESCRIPTION
Not doing this is bad practise and leads to a warning with recent
compilers.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>