### PR TITLE
ULT fix: need to return a 2.0 platform to use 2.0 queue creation function

### DIFF
--- a/tests/test_clhpp.cpp
+++ b/tests/test_clhpp.cpp
@@ -1058,7 +1058,11 @@ void testBufferConstructorContextIterator()
     clCreateBuffer_StubWithCallback(clCreateBuffer_testBufferConstructorContextIterator);
     clGetContextInfo_StubWithCallback(clGetContextInfo_device);
     clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
+#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_2_0);
+#else // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
     clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_2);
+#endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
     clRetainDevice_ExpectAndReturn(make_device_id(0), CL_SUCCESS);
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200


### PR DESCRIPTION
This change fixes a failing cl2hpp ULT.  When the ULT returned 1.2 as its platform version, the headers were using the OpenCL 1.x clCreateCommandQueue API rather than the stubbed clCreateCommandQueueWithProperties API.  Fix is to return 2.0 as the platform version when the ULT is testing the OpenCL 2.x clCreateCommandQueueWithProperties API.