### PR TITLE
Don't paralellise Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   - cmake -DOPENCL_LIB_DIR=${TOP}/OpenCL-ICD-Loader/build
           -DOPENCL_INCLUDE_DIR=${TOP}/OpenCL-Headers
           ..
-  - make -j2
+  - make
   - ctest


### PR DESCRIPTION
We seem to be missing dependencies in the build system.

Signed-off-by: Kévin Petit <kevin.petit@arm.com>