### PR TITLE
Fix the cmake command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bindings (adapt paths as required):
     cd OpenCL-CLHPP
     mkdir build
     cd build
-    cmake -DOPENCL_INCLUDE_DIR=/path/to/OpenCL/headers -DOPENCL_LIB_DIR=/path/to/OpenCL/library
+    cmake .. -DOPENCL_INCLUDE_DIR=/path/to/OpenCL/headers -DOPENCL_LIB_DIR=/path/to/OpenCL/library
     make
     make test
 ```


### PR DESCRIPTION
The cmake command was missing the path to the source directory (..)