### PR TITLE
fix cl2.hpp for UBSAN

### DIFF
--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -547,7 +547,9 @@
 #define CL_HPP_NOEXCEPT_
 #endif
 
-#if defined(_MSC_VER)
+#if __cplusplus >= 201703L
+# define CL_HPP_DEFINE_STATIC_MEMBER_ inline
+#elif defined(_MSC_VER)
 # define CL_HPP_DEFINE_STATIC_MEMBER_ __declspec(selectany)
 #elif defined(__MINGW32__)
 # define CL_HPP_DEFINE_STATIC_MEMBER_ __attribute__((selectany))


### PR DESCRIPTION
It seems to me, that https://github.com/KhronosGroup/OpenCL-CLHPP/issues/17 was only solved for `cl.hpp` but not for `cl2.cpp`.

This pull request implements the same change as https://github.com/KhronosGroup/OpenCL-CLHPP/commit/a807dcf0f8623d40dc5ce9d1eb00ffd0e46150c7 but for `cl2.cpp`.

If c++17 or above is detected, then `inline` is used for `CL_HPP_DEFINE_STATIC_MEMBER_`.