### PR TITLE
Updates cl2.hpp and cl.hpp to handle case of platform with zero devices without error.

### DIFF
--- a/include/CL/cl.hpp
+++ b/include/CL/cl.hpp
@@ -2267,17 +2267,21 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
         cl_int err = ::clGetDeviceIDs(object_, type, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
+        if (err != CL_SUCCESS && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
         }
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = ::clGetDeviceIDs(object_, type, n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
-
-        devices->assign(&ids[0], &ids[n]);
+        if (n > 0) {
+                cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
+                err = ::clGetDeviceIDs(object_, type, n, ids, NULL);
+                if (err != CL_SUCCESS) {
+                    return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
+                }
+        
+                devices->assign(&ids[0], &ids[n]);
+        } else {
+		devices->clear();
+	}
         return CL_SUCCESS;
     }
 

--- a/include/CL/cl.hpp
+++ b/include/CL/cl.hpp
@@ -2280,8 +2280,8 @@ public:
         
                 devices->assign(&ids[0], &ids[n]);
         } else {
-		devices->clear();
-	}
+            devices->clear();
+        }
         return CL_SUCCESS;
     }
 

--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -2499,14 +2499,16 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
         cl_int err = ::clGetDeviceIDs(object_, type, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
+        if (err != CL_SUCCESS  && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
         }
 
         vector<cl_device_id> ids(n);
-        err = ::clGetDeviceIDs(object_, type, n, ids.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
+        if (n>0) {
+            err = ::clGetDeviceIDs(object_, type, n, ids.data(), NULL);
+            if (err != CL_SUCCESS) {
+                return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
+            }
         }
 
         // Cannot trivially assign because we need to capture intermediates 

--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -2267,17 +2267,21 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
         cl_int err = ::clGetDeviceIDs(object_, type, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
+        if (err != CL_SUCCESS && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
         }
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = ::clGetDeviceIDs(object_, type, n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
+        if (n > 0) {
+                cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
+                err = ::clGetDeviceIDs(object_, type, n, ids, NULL);
+                if (err != CL_SUCCESS) {
+                    return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
+                }
+        
+                devices->assign(&ids[0], &ids[n]);
+        } else {
+            devices->clear();
         }
-
-        devices->assign(&ids[0], &ids[n]);
         return CL_SUCCESS;
     }
 


### PR DESCRIPTION
Need to more carefully handle the case of a platform detected with zero devices.  In the first call to clGetDeviceIDs, this will return code CL_DEVICE_NOT_FOUND and set n=0 if no devices are reported by the platform. ( https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetDeviceIDs.html )
The second call to clGetDeviceIDs cannot be allowed occur if n=0, otherwise CL_INVALID_VALUE is reported.
A platform with zero devices is not an error condition.  Device enumeration should simply move on.