### PR TITLE
fixed CL_WEAK_ATTRIB_PREFIX and CL_WEAK_ATTRIB_SUFFIX for mingw

### DIFF
--- a/include/CL/cl.hpp
+++ b/include/CL/cl.hpp
@@ -246,9 +246,12 @@
 #ifdef CL_USE_INLINE
 #define CL_WEAK_ATTRIB_PREFIX inline
 #define CL_WEAK_ATTRIB_SUFFIX
-#elif _WIN32
+#elif defined(_MSC_VER)
 #define CL_WEAK_ATTRIB_PREFIX __declspec(selectany)
 #define CL_WEAK_ATTRIB_SUFFIX
+#elif defined(__MINGW32__)
+#define CL_WEAK_ATTRIB_PREFIX
+#define CL_WEAK_ATTRIB_SUFFIX __attribute__((selectany))
 #else // GCC, CLANG, etc.
 #define CL_WEAK_ATTRIB_PREFIX
 #define CL_WEAK_ATTRIB_SUFFIX __attribute__((weak))

--- a/input_cl.hpp
+++ b/input_cl.hpp
@@ -246,9 +246,12 @@
 #ifdef CL_USE_INLINE
 #define CL_WEAK_ATTRIB_PREFIX inline
 #define CL_WEAK_ATTRIB_SUFFIX
-#elif _WIN32
+#elif defined(_MSC_VER)
 #define CL_WEAK_ATTRIB_PREFIX __declspec(selectany)
 #define CL_WEAK_ATTRIB_SUFFIX
+#elif defined(__MINGW32__)
+#define CL_WEAK_ATTRIB_PREFIX
+#define CL_WEAK_ATTRIB_SUFFIX __attribute__((selectany))
 #else // GCC, CLANG, etc.
 #define CL_WEAK_ATTRIB_PREFIX
 #define CL_WEAK_ATTRIB_SUFFIX __attribute__((weak))


### PR DESCRIPTION
Previously these macros were set to `__declspec(selectany)` for all windows builds (based on `_WIN32` macro). This PR defines the correct macro for mingw by using `_MSC_VER` and `__MINGW32__` macros. This is identical to the way `cl2.hpp` defines similar macros.