### PR TITLE
Fix test build with optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
 endif()
 
 if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Werror=return-type")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 endif()
 

--- a/tests/test_cl2hpp.cpp
+++ b/tests/test_cl2hpp.cpp
@@ -443,6 +443,7 @@ static cl_int clGetPipeInfo_testCreatePipe(
     }
     else {
         TEST_FAIL();
+        return CL_INVALID_VALUE;
     }
 }
 
@@ -492,12 +493,14 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfo_testSubGroups(cl_kernel kernel
         if (param_value_size_ret) {
             *param_value_size_ret = sizeof(size_t);
         }
+        return CL_SUCCESS;
     }
     else if (param_name == CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR) {
         *static_cast<size_t*>(param_value) = 2;
         if (param_value_size_ret) {
             *param_value_size_ret = sizeof(size_t);
         }
+        return CL_SUCCESS;
     }
     else {
         TEST_ABORT();


### PR DESCRIPTION
When building with optimizations on, `test_cl2hpp` segfaulted with both
GCC and Clang. Both compilers tell us why: if a function with non-void
return type does not return via return statement, this is undefined
behavior.

Luckily this can be reliably prevented at compile-time via
`-Werror=return-type`, so we add that flag.