### PR TITLE
Detect availability of noexcept via _MSVC_LANG

### DIFF
--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -529,7 +529,7 @@
 #include <CL/opencl.h>
 #endif // !__APPLE__
 
-#if (__cplusplus >= 201103L)
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L )
 #define CL_HPP_NOEXCEPT_ noexcept
 #else
 #define CL_HPP_NOEXCEPT_


### PR DESCRIPTION
If compiling with Visual Studio, __cplusplus does not hold
an updated value by default, therefore test _MSVC_LANG.

Fixes #93 