### PR TITLE
Enable OpenCL 3.0 APIs when building tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(
     ${UNITY_DIR}/src
     ${CMOCK_DIR}/src)
 
-add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
+add_definitions(-DCL_TARGET_OPENCL_VERSION=300)
 add_definitions(-DCL_EXPERIMENTAL)
 
 add_definitions(-DUNITY_SUPPORT_64)


### PR DESCRIPTION
This is needed for the auto-generated mocking functions.

CI will be broken for other PRs until this lands.