### PR TITLE
add initial support for OpenCL 3.0 platform and device queries

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -18,7 +18,7 @@
  *
  *   \brief C++ bindings for OpenCL 1.0 (rev 48), OpenCL 1.1 (rev 33),
  *       OpenCL 1.2 (rev 15), OpenCL 2.0 (rev 29), OpenCL 2.1 (rev 17),
- *       and OpenCL 2.2 (V2.2-11).
+ *       OpenCL 2.2 (V2.2-11), and OpenCL 3.0 (V3.0.1-Provisional).
  *   \author Lee Howes and Bruce Merry
  *
  *   Derived from the OpenCL 1.x C++ bindings written by
@@ -1383,15 +1383,41 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT , cl_uint) \
     F(cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, cl::vector<cl_device_partition_property_ext>)
 
-#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_(F) \
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_SHARED_(F) \
     F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION_KHR, cl_version_khr) \
     F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>) \
     \
     F(cl_device_info, CL_DEVICE_NUMERIC_VERSION_KHR, cl_version_khr) \
-    F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr) \
     F(cl_device_info, CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>) \
     F(cl_device_info, CL_DEVICE_ILS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>) \
     F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>)
+
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_UNIQUE_(F) \
+    F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr)
+
+#define CL_HPP_PARAM_NAME_INFO_3_0_(F) \
+    F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION, cl_version) \
+    F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION, cl::vector<cl_name_version>) \
+    \
+    F(cl_device_info, CL_DEVICE_NUMERIC_VERSION, cl_version) \
+    F(cl_device_info, CL_DEVICE_EXTENSIONS_WITH_VERSION, cl::vector<cl_name_version>) \
+    F(cl_device_info, CL_DEVICE_ILS_WITH_VERSION, cl::vector<cl_name_version>) \
+    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION, cl::vector<cl_name_version>) \
+    F(cl_device_info, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES, cl_device_atomic_capabilities) \
+    F(cl_device_info, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES, cl_device_atomic_capabilities) \
+    F(cl_device_info, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT, cl_bool) \
+    F(cl_device_info, CL_DEVICE_OPENCL_C_ALL_VERSIONS, cl::vector<cl_name_version>) \
+    F(cl_device_info, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, size_type) \
+    F(cl_device_info, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT, cl_bool) \
+    F(cl_device_info, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT, cl_bool) \
+    F(cl_device_info, CL_DEVICE_OPENCL_C_FEATURES, cl::vector<cl_name_version>) \
+    F(cl_device_info, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES, cl_device_device_enqueue_capabilities) \
+    F(cl_device_info, CL_DEVICE_PIPE_SUPPORT, cl_bool) \
+    \
+    F(cl_command_queue_info, CL_QUEUE_PROPERTIES_ARRAY, cl::vector<cl_queue_properties>) \
+    F(cl_mem_info, CL_MEM_PROPERTIES, cl::vector<cl_mem_properties>) \
+    F(cl_pipe_info, CL_PIPE_PROPERTIES, cl::vector<cl_pipe_properties>) \
+    F(cl_sampler_info, CL_SAMPLER_PROPERTIES, cl::vector<cl_sampler_properties>)
 
 template <typename enum_type, cl_int Name>
 struct param_traits {};
@@ -1421,6 +1447,9 @@ CL_HPP_PARAM_NAME_INFO_2_1_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 220
 CL_HPP_PARAM_NAME_INFO_2_2_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 220
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+CL_HPP_PARAM_NAME_INFO_3_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 300
 
 #if defined(CL_HPP_USE_CL_SUB_GROUPS_KHR) && CL_HPP_TARGET_OPENCL_VERSION < 210
 CL_HPP_PARAM_NAME_INFO_SUBGROUP_KHR_(CL_HPP_DECLARE_PARAM_TRAITS_)
@@ -1458,7 +1487,10 @@ CL_HPP_PARAM_NAME_DEVICE_FISSION_(CL_HPP_DECLARE_PARAM_TRAITS_);
 #endif // CL_HPP_USE_CL_DEVICE_FISSION
 
 #if defined(cl_khr_extended_versioning)
-CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_(CL_HPP_DECLARE_PARAM_TRAITS_);
+#if CL_HPP_TARGET_OPENCL_VERSION < 300
+CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_SHARED_(CL_HPP_DECLARE_PARAM_TRAITS_);
+#endif // CL_HPP_TARGET_OPENCL_VERSION < 300
+CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_UNIQUE_(CL_HPP_DECLARE_PARAM_TRAITS_);
 #endif // cl_khr_extended_versioning
 
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR
@@ -3238,7 +3270,7 @@ public:
      */
     cl_int setCallback(
         cl_int type,
-        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),		
+        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -3427,7 +3459,7 @@ public:
      *  value - not the Memory class instance.
      */
     cl_int setDestructorCallback(
-        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),		
+        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -4018,7 +4050,7 @@ public:
         }
 
         return result;
-    }		
+    }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 };
 

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -16,9 +16,8 @@
 
 /*! \file
  *
- *   \brief C++ bindings for OpenCL 1.0 (rev 48), OpenCL 1.1 (rev 33),
- *       OpenCL 1.2 (rev 15), OpenCL 2.0 (rev 29), OpenCL 2.1 (rev 17),
- *       OpenCL 2.2 (V2.2-11), and OpenCL 3.0 (V3.0.1-Provisional).
+ *   \brief C++ bindings for OpenCL 1.0, OpenCL 1.1, OpenCL 1.2,
+ *       OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, and OpenCL 3.0.
  *   \author Lee Howes and Bruce Merry
  *
  *   Derived from the OpenCL 1.x C++ bindings written by
@@ -435,8 +434,8 @@
 
 /* Detect which version to target */
 #if !defined(CL_HPP_TARGET_OPENCL_VERSION)
-# pragma message("opencl.hpp: CL_HPP_TARGET_OPENCL_VERSION is not defined. It will default to 220 (OpenCL 2.2)")
-# define CL_HPP_TARGET_OPENCL_VERSION 220
+# pragma message("opencl.hpp: CL_HPP_TARGET_OPENCL_VERSION is not defined. It will default to 300 (OpenCL 3.0)")
+# define CL_HPP_TARGET_OPENCL_VERSION 300
 #endif
 #if CL_HPP_TARGET_OPENCL_VERSION != 100 && \
     CL_HPP_TARGET_OPENCL_VERSION != 110 && \
@@ -445,9 +444,9 @@
     CL_HPP_TARGET_OPENCL_VERSION != 210 && \
     CL_HPP_TARGET_OPENCL_VERSION != 220 && \
     CL_HPP_TARGET_OPENCL_VERSION != 300
-# pragma message("opencl.hpp: CL_HPP_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220 or 300). It will be set to 220")
+# pragma message("opencl.hpp: CL_HPP_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220 or 300). It will be set to 300 (OpenCL 3.0).")
 # undef CL_HPP_TARGET_OPENCL_VERSION
-# define CL_HPP_TARGET_OPENCL_VERSION 220
+# define CL_HPP_TARGET_OPENCL_VERSION 300
 #endif
 
 /* Forward target OpenCL version to C headers if necessary */
@@ -1383,7 +1382,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT , cl_uint) \
     F(cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, cl::vector<cl_device_partition_property_ext>)
 
-#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_SHARED_(F) \
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_CL3_SHARED_(F) \
     F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION_KHR, cl_version_khr) \
     F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>) \
     \
@@ -1392,7 +1391,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_ILS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>) \
     F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR, cl::vector<cl_name_version_khr>)
 
-#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_UNIQUE_(F) \
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(F) \
     F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr)
 
 #define CL_HPP_PARAM_NAME_INFO_3_0_(F) \
@@ -1488,9 +1487,9 @@ CL_HPP_PARAM_NAME_DEVICE_FISSION_(CL_HPP_DECLARE_PARAM_TRAITS_);
 
 #if defined(cl_khr_extended_versioning)
 #if CL_HPP_TARGET_OPENCL_VERSION < 300
-CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_SHARED_(CL_HPP_DECLARE_PARAM_TRAITS_);
+CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_CL3_SHARED_(CL_HPP_DECLARE_PARAM_TRAITS_);
 #endif // CL_HPP_TARGET_OPENCL_VERSION < 300
-CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_UNIQUE_(CL_HPP_DECLARE_PARAM_TRAITS_);
+CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(CL_HPP_DECLARE_PARAM_TRAITS_);
 #endif // cl_khr_extended_versioning
 
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1412,6 +1412,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_OPENCL_C_FEATURES, cl::vector<cl_name_version>) \
     F(cl_device_info, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES, cl_device_device_enqueue_capabilities) \
     F(cl_device_info, CL_DEVICE_PIPE_SUPPORT, cl_bool) \
+    F(cl_device_info, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED, string) \
     \
     F(cl_command_queue_info, CL_QUEUE_PROPERTIES_ARRAY, cl::vector<cl_queue_properties>) \
     F(cl_mem_info, CL_MEM_PROPERTIES, cl::vector<cl_mem_properties>) \

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -15,6 +15,8 @@ extern "C"
 #include "Mockcl.h"
 #include <string.h>
 
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
 /// Creates fake IDs that are easy to identify
 
 static inline cl_platform_id make_platform_id(int index)
@@ -2500,8 +2502,28 @@ void testSetProgramSpecializationConstantPointer()
 
 // OpenCL 3.0 and cl_khr_extended_versioning Queries
 
-// Note: This assumes the core enums, structures, and macros exactly match
-// the extension enums, structures, and macros.
+// Assumes the core enums, structures, and macros exactly match
+// the extension enums, structures, and macros:
+
+static_assert(CL_PLATFORM_NUMERIC_VERSION == CL_PLATFORM_NUMERIC_VERSION_KHR,
+    "CL_PLATFORM_NUMERIC_VERSION mismatch");
+static_assert(CL_PLATFORM_EXTENSIONS_WITH_VERSION == CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR,
+    "CL_PLATFORM_EXTENSIONS_WITH_VERSION mismatch");
+
+static_assert(CL_DEVICE_NUMERIC_VERSION == CL_DEVICE_NUMERIC_VERSION_KHR,
+    "CL_DEVICE_NUMERIC_VERSION mismatch");
+static_assert(CL_DEVICE_EXTENSIONS_WITH_VERSION == CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR,
+    "CL_DEVICE_EXTENSIONS_WITH_VERSION mismatch");
+static_assert(CL_DEVICE_ILS_WITH_VERSION == CL_DEVICE_ILS_WITH_VERSION_KHR,
+    "CL_DEVICE_ILS_WITH_VERSION mismatch");
+static_assert(CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION == CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR,
+    "CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION mismatch");
+
+static_assert(sizeof(cl_name_version) == sizeof(cl_name_version_khr),
+    "cl_name_version mismatch");
+
+static_assert(CL_MAKE_VERSION(1, 2, 3) == CL_MAKE_VERSION_KHR(1, 2, 3),
+    "CL_MAKE_VERSION mismatch");
 
 static cl_int clGetPlatformInfo_extended_versioning(
     cl_platform_id id,
@@ -2675,10 +2697,9 @@ static cl_int clGetDeviceInfo_extended_versioning(
         };
         if (param_value_size == sizeof(opencl_c_features) && param_value) {
             cl_name_version* feature = static_cast<cl_name_version*>(param_value);
-            const int numFeatures = sizeof(opencl_c_features) / sizeof(opencl_c_features[0]);
+            const int numFeatures = ARRAY_SIZE(opencl_c_features);
             for (int i = 0; i < numFeatures; i++) {
-                *feature = opencl_c_features[i];
-                ++feature;
+                feature[i] = opencl_c_features[i];
             }
         }
         if (param_value_size_ret) {

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -217,6 +217,24 @@ static cl_int clGetPlatformInfo_version_2_0(
         param_value_size_ret, "OpenCL 2.0 Mock");
 }
 
+/**
+ * A stub for clGetPlatformInfo that will only support querying
+ * CL_PLATFORM_VERSION, and will return version 3.0.
+ */
+static cl_int clGetPlatformInfo_version_3_0(
+    cl_platform_id id,
+    cl_platform_info param_name,
+    size_t param_value_size,
+    void *param_value,
+    size_t *param_value_size_ret,
+    int num_calls)
+{
+    (void) num_calls;
+    return clGetPlatformInfo_version(
+        id, param_name, param_value_size, param_value,
+        param_value_size_ret, "OpenCL 3.0 Mock");
+}
+
 /* Simulated reference counts. The table points to memory held by the caller.
  * This makes things simpler in the common case of only one object to be
  * reference counted.
@@ -2480,7 +2498,10 @@ void testSetProgramSpecializationConstantPointer()
 #endif
 }
 
-// cl_khr_extended_versioning
+// OpenCL 3.0 and cl_khr_extended_versioning Queries
+
+// Note: This assumes the core enums, structures, and macros exactly match
+// the extension enums, structures, and macros.
 
 static cl_int clGetPlatformInfo_extended_versioning(
     cl_platform_id id,
@@ -2492,24 +2513,24 @@ static cl_int clGetPlatformInfo_extended_versioning(
 {
     (void)num_calls;
     switch (param_name) {
-    case CL_PLATFORM_NUMERIC_VERSION_KHR:
+    case CL_PLATFORM_NUMERIC_VERSION:
     {
-        if (param_value_size == sizeof(cl_version_khr) && param_value) {
-            *static_cast<cl_version_khr*>(param_value) = CL_MAKE_VERSION_KHR(1, 2, 3);
+        if (param_value_size == sizeof(cl_version) && param_value) {
+            *static_cast<cl_version*>(param_value) = CL_MAKE_VERSION(1, 2, 3);
         }
         if (param_value_size_ret) {
-            *param_value_size_ret = sizeof(cl_version_khr);
+            *param_value_size_ret = sizeof(cl_version);
         }
         return CL_SUCCESS;
     }
-    case CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR:
+    case CL_PLATFORM_EXTENSIONS_WITH_VERSION:
     {
-        static cl_name_version_khr extension = {
-            CL_MAKE_VERSION_KHR(10, 11, 12),
+        static cl_name_version extension = {
+            CL_MAKE_VERSION(10, 11, 12),
             "cl_dummy_extension",
         };
-        if (param_value_size == sizeof(cl_name_version_khr) && param_value) {
-            *static_cast<cl_name_version_khr*>(param_value) = extension;
+        if (param_value_size == sizeof(cl_name_version) && param_value) {
+            *static_cast<cl_name_version*>(param_value) = extension;
         }
         if (param_value_size_ret) {
             *param_value_size_ret = sizeof(extension);
@@ -2522,8 +2543,26 @@ static cl_int clGetPlatformInfo_extended_versioning(
     return CL_INVALID_OPERATION;
 }
 
-void testPlatformExtendedVersioning()
+void testPlatformExtendedVersioning_3_0()
 {
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    cl::Platform p(make_platform_id(1));
+
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_extended_versioning);
+
+    cl_version platformVersion = p.getInfo<CL_PLATFORM_NUMERIC_VERSION>();
+    TEST_ASSERT_EQUAL_HEX(platformVersion, CL_MAKE_VERSION(1, 2, 3));
+
+    std::vector<cl_name_version> extensions = p.getInfo<CL_PLATFORM_EXTENSIONS_WITH_VERSION>();
+    TEST_ASSERT_EQUAL(extensions.size(), 1);
+    TEST_ASSERT_EQUAL_HEX(extensions[0].version, CL_MAKE_VERSION(10, 11, 12));
+    TEST_ASSERT_EQUAL_STRING(extensions[0].name, "cl_dummy_extension");
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 300
+}
+
+void testPlatformExtendedVersioning_KHR()
+{
+#if CL_HPP_TARGET_OPENCL_VERSION < 300
     cl::Platform p(make_platform_id(1));
 
     clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_extended_versioning);
@@ -2535,7 +2574,12 @@ void testPlatformExtendedVersioning()
     TEST_ASSERT_EQUAL(extensions.size(), 1);
     TEST_ASSERT_EQUAL_HEX(extensions[0].version, CL_MAKE_VERSION_KHR(10, 11, 12));
     TEST_ASSERT_EQUAL_STRING(extensions[0].name, "cl_dummy_extension");
+#endif // CL_HPP_TARGET_OPENCL_VERSION < 300
 }
+
+
+// Note: This assumes the core enums, structures, and macros exactly match
+// the extension enums, structures, and macros.
 
 static cl_int clGetDeviceInfo_extended_versioning(
     cl_device_id id,
@@ -2547,13 +2591,13 @@ static cl_int clGetDeviceInfo_extended_versioning(
 {
     (void)num_calls;
     switch (param_name) {
-    case CL_DEVICE_NUMERIC_VERSION_KHR:
+    case CL_DEVICE_NUMERIC_VERSION:
     {
-        if (param_value_size == sizeof(cl_version_khr) && param_value) {
-            *static_cast<cl_version_khr*>(param_value) = CL_MAKE_VERSION_KHR(1, 2, 3);
+        if (param_value_size == sizeof(cl_version) && param_value) {
+            *static_cast<cl_version*>(param_value) = CL_MAKE_VERSION(1, 2, 3);
         }
         if (param_value_size_ret) {
-            *param_value_size_ret = sizeof(cl_version_khr);
+            *param_value_size_ret = sizeof(cl_version);
         }
         return CL_SUCCESS;
     }
@@ -2567,39 +2611,78 @@ static cl_int clGetDeviceInfo_extended_versioning(
         }
         return CL_SUCCESS;
     }
-    case CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR:
+    case CL_DEVICE_EXTENSIONS_WITH_VERSION:
     {
-        static cl_name_version_khr extension = {
-            CL_MAKE_VERSION_KHR(10, 11, 12),
+        static cl_name_version extension = {
+            CL_MAKE_VERSION(10, 11, 12),
             "cl_dummy_extension",
         };
-        if (param_value_size == sizeof(cl_name_version_khr) && param_value) {
-            *static_cast<cl_name_version_khr*>(param_value) = extension;
+        if (param_value_size == sizeof(cl_name_version) && param_value) {
+            *static_cast<cl_name_version*>(param_value) = extension;
         }
         if (param_value_size_ret) {
             *param_value_size_ret = sizeof(extension);
         }
         return CL_SUCCESS;
     }
-    case CL_DEVICE_ILS_WITH_VERSION_KHR:
+    case CL_DEVICE_ILS_WITH_VERSION:
     {
-        static cl_name_version_khr il = {
-            CL_MAKE_VERSION_KHR(20, 21, 22),
+        static cl_name_version il = {
+            CL_MAKE_VERSION(20, 21, 22),
             "DUMMY_IR",
         };
-        if (param_value_size == sizeof(cl_name_version_khr) && param_value) {
-            *static_cast<cl_name_version_khr*>(param_value) = il;
+        if (param_value_size == sizeof(cl_name_version) && param_value) {
+            *static_cast<cl_name_version*>(param_value) = il;
         }
         if (param_value_size_ret) {
             *param_value_size_ret = sizeof(il);
         }
         return CL_SUCCESS;
     }
-    case CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR:
+    case CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION:
     {
         // Test no built-in kernels:
         if (param_value_size_ret) {
             *param_value_size_ret = 0;
+        }
+        return CL_SUCCESS;
+    }
+    case CL_DEVICE_OPENCL_C_ALL_VERSIONS:
+    {
+        static cl_name_version opencl_c = {
+            CL_MAKE_VERSION(30, 31, 32),
+            "OpenCL C",
+        };
+        if (param_value_size == sizeof(cl_name_version) && param_value) {
+            *static_cast<cl_name_version*>(param_value) = opencl_c;
+        }
+        if (param_value_size_ret) {
+            *param_value_size_ret = sizeof(opencl_c);
+        }
+        return CL_SUCCESS;
+    }
+    case CL_DEVICE_OPENCL_C_FEATURES:
+    {
+        static cl_name_version opencl_c_features[] = {
+            {
+                CL_MAKE_VERSION(40, 41, 42),
+                "__opencl_c_feature",
+            },
+            {
+                CL_MAKE_VERSION(40, 43, 44),
+                "__opencl_c_fancy_feature",
+            },
+        };
+        if (param_value_size == sizeof(opencl_c_features) && param_value) {
+            cl_name_version* feature = static_cast<cl_name_version*>(param_value);
+            const int numFeatures = sizeof(opencl_c_features) / sizeof(opencl_c_features[0]);
+            for (int i = 0; i < numFeatures; i++) {
+                *feature = opencl_c_features[i];
+                ++feature;
+            }
+        }
+        if (param_value_size_ret) {
+            *param_value_size_ret = sizeof(opencl_c_features);
         }
         return CL_SUCCESS;
     }
@@ -2609,8 +2692,50 @@ static cl_int clGetDeviceInfo_extended_versioning(
     return CL_INVALID_OPERATION;
 }
 
-void testDeviceExtendedVersioning()
+void testDeviceExtendedVersioning_3_0()
 {
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_3_0);
+    clReleaseDevice_ExpectAndReturn(make_device_id(0), CL_SUCCESS);
+
+    cl::Device d0(make_device_id(0));
+
+    clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_extended_versioning);
+
+    cl_version deviceVersion = d0.getInfo<CL_DEVICE_NUMERIC_VERSION>();
+    TEST_ASSERT_EQUAL_HEX(deviceVersion, CL_MAKE_VERSION(1, 2, 3));
+
+    std::vector<cl_name_version> extensions = d0.getInfo<CL_DEVICE_EXTENSIONS_WITH_VERSION>();
+    TEST_ASSERT_EQUAL(extensions.size(), 1);
+    TEST_ASSERT_EQUAL_HEX(extensions[0].version, CL_MAKE_VERSION(10, 11, 12));
+    TEST_ASSERT_EQUAL_STRING(extensions[0].name, "cl_dummy_extension");
+
+    std::vector<cl_name_version> ils = d0.getInfo<CL_DEVICE_ILS_WITH_VERSION>();
+    TEST_ASSERT_EQUAL(ils.size(), 1);
+    TEST_ASSERT_EQUAL_HEX(ils[0].version, CL_MAKE_VERSION(20, 21, 22));
+    TEST_ASSERT_EQUAL_STRING(ils[0].name, "DUMMY_IR");
+
+    std::vector<cl_name_version> opencl_c = d0.getInfo<CL_DEVICE_OPENCL_C_ALL_VERSIONS>();
+    TEST_ASSERT_EQUAL(opencl_c.size(), 1);
+    TEST_ASSERT_EQUAL_HEX(opencl_c[0].version, CL_MAKE_VERSION(30, 31, 32));
+    TEST_ASSERT_EQUAL_STRING(opencl_c[0].name, "OpenCL C");
+
+    std::vector<cl_name_version> opencl_c_features = d0.getInfo<CL_DEVICE_OPENCL_C_FEATURES>();
+    TEST_ASSERT_EQUAL(opencl_c_features.size(), 2);
+    TEST_ASSERT_EQUAL_HEX(opencl_c_features[0].version, CL_MAKE_VERSION(40, 41, 42));
+    TEST_ASSERT_EQUAL_STRING(opencl_c_features[0].name, "__opencl_c_feature");
+    TEST_ASSERT_EQUAL_HEX(opencl_c_features[1].version, CL_MAKE_VERSION(40, 43, 44));
+    TEST_ASSERT_EQUAL_STRING(opencl_c_features[1].name, "__opencl_c_fancy_feature");
+
+    std::vector<cl_name_version> builtInKernels = d0.getInfo<CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION>();
+    TEST_ASSERT_EQUAL(builtInKernels.size(), 0);
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 300
+}
+
+void testDeviceExtendedVersioning_KHR()
+{
+#if CL_HPP_TARGET_OPENCL_VERSION < 300
     clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
     clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_2_0);
     clReleaseDevice_ExpectAndReturn(make_device_id(0), CL_SUCCESS);
@@ -2637,6 +2762,8 @@ void testDeviceExtendedVersioning()
 
     std::vector<cl_name_version_khr> builtInKernels = d0.getInfo<CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR>();
     TEST_ASSERT_EQUAL(builtInKernels.size(), 0);
+#endif // CL_HPP_TARGET_OPENCL_VERSION < 300
 }
+
 
 } // extern "C"


### PR DESCRIPTION
Adds initial support for OpenCL 3.0 by adding the new OpenCL 3.0 platform and device queries.

A few notes:

* This needs to be merged after https://github.com/KhronosGroup/OpenCL-Headers/pull/96, since it relies on the device enqueue capabilities query and not the device enqueue boolean query.

* I'd specifically like feedback regarding interactions with the `cl_khr_extended_versioning` extension, since OpenCL 3.0 shares many of the queries with `cl_khr_extended_versioning`.  I've done this for now by separating the `cl_khr_extended_versioning` queries into "shared" queries that are also in OpenCL 3.0 and "unique" queries that aren't, but I'm open to suggestions to do this differently.

* An example application that uses these new queries can be found here: [newqueriespp](https://github.com/bashbaug/SimpleOpenCLSamples/tree/master/samples/00_newqueriespp).