### PR TITLE
Update doc on binaries argument of cl::Program()

### DIFF
--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -6434,7 +6434,7 @@ public:
      * Construct a program object from a list of devices and a per-device list of binaries.
      * \param context A valid OpenCL context in which to construct the program.
      * \param devices A vector of OpenCL device objects for which the program will be created.
-     * \param binaries A vector of pairs of a pointer to a binary object and its length.
+     * \param binaries A vector of vectors containing the binary objects.
      * \param binaryStatus An optional vector that on completion will be resized to
      *   match the size of binaries and filled with values to specify if each binary
      *   was successfully loaded.


### PR DESCRIPTION
The current documentation still describes the `binaries` argument to `cl::Program` as pair of pointer and length as in the old cl.hpp. Update to reflect the new default in cl2.hpp.