### PR TITLE
Fix enqueueMapSVM for cl::vector

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -8150,7 +8150,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(::clEnqueueSVMMap(
-            object_, blocking, flags, static_cast<void*>(container.data()), container.size(),
+            object_, blocking, flags, static_cast<void*>(container.data()), container.size()*sizeof(T),
             (events != NULL) ? (cl_uint)events->size() : 0,
             (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
             (event != NULL) ? &tmp : NULL),

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -2346,6 +2346,14 @@ void testCloneKernel()
 #endif
 }
 
+void testEnqueueMapSVM()
+{
+#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+    std::vector<int> vec(7);
+    clEnqueueSVMMap_ExpectAndReturn(commandQueuePool[0].get(), CL_TRUE, CL_MAP_READ|CL_MAP_WRITE, static_cast<void*>(vec.data()), vec.size()*sizeof(int), 0, NULL, NULL, CL_SUCCESS);
+    TEST_ASSERT_EQUAL(commandQueuePool[0].enqueueMapSVM(vec, CL_TRUE, CL_MAP_READ|CL_MAP_WRITE), CL_SUCCESS);
+#endif
+}
 
 // Run after other tests to clear the default state in the header
 // using special unit test bypasses.


### PR DESCRIPTION
The proposed fix passes the container size _in bytes_ to clEnqueueSVMMap.