### PR TITLE
Add partial support for cl_arm_scheduling_controls

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1346,6 +1346,8 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint) \
     F(cl_device_info, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT, cl_uint) \
     F(cl_profiling_info, CL_PROFILING_COMMAND_COMPLETE, cl_ulong) \
+    F(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM, cl_bool) \
+    F(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_SVM_PTRS, void**) \
     F(cl_command_queue_info, CL_QUEUE_SIZE, cl_uint) \
     F(cl_mem_info, CL_MEM_USES_SVM_POINTER, cl_bool) \
     F(cl_program_build_info, CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE, size_type) \
@@ -1509,6 +1511,12 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_JOB_SLOTS_ARM, cl_uint)
 #endif
 #ifdef CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM, cl_bitfield)
+#endif
+#ifdef CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM, cl_uint)
+#endif
+#ifdef CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM, cl_int)
 #endif
 
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
@@ -6160,6 +6168,12 @@ public:
             param_name,
             sizeof(T),
             &val));
+    }
+
+    template<cl_kernel_exec_info name>
+    cl_int setExecInfo(typename detail::param_traits<detail::cl_kernel_exec_info, name>::param_type& val)
+    {
+        return setExecInfo(name, val);
     }
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1507,6 +1507,9 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMPUTE_UNITS_BITFIELD_AR
 #ifdef CL_DEVICE_JOB_SLOTS_ARM
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_JOB_SLOTS_ARM, cl_uint)
 #endif
+#ifdef CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM, cl_bitfield)
+#endif
 
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, cl_uint)
@@ -6146,6 +6149,17 @@ public:
             CL_KERNEL_EXEC_INFO_SVM_PTRS,
             sizeof(void*)*(1 + sizeof...(Ts)),
             pointerList.data()));
+    }
+
+    template<typename T>
+    cl_int setExecInfo(cl_kernel_exec_info param_name, const T& val)
+    {
+        return detail::errHandler(
+            ::clSetKernelExecInfo(
+            object_,
+            param_name,
+            sizeof(T),
+            &val));
     }
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -1546,6 +1546,11 @@ void testKernelSetExecInfo()
                                         CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
                                         sizeof(cl_bool), &val, CL_SUCCESS);
     kernelPool[0].setExecInfo(CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM, val);
+    // Also test the typesafe version
+    clSetKernelExecInfo_ExpectAndReturn(make_kernel(0),
+                                        CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
+                                        sizeof(cl_bool), &val, CL_SUCCESS);
+    kernelPool[0].setExecInfo<CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM>(val);
 #endif
 }
 

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -1535,6 +1535,20 @@ void testKernelSetArgLocal()
     kernelPool[0].setArg(2, cl::Local(123));
 }
 
+void testKernelSetExecInfo()
+{
+#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+    cl_bool val = CL_TRUE;
+    // Using CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM in the tests since it's
+    // defined by the core spec but this function is particularly useful for
+    // vendor extensions.
+    clSetKernelExecInfo_ExpectAndReturn(make_kernel(0),
+                                        CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
+                                        sizeof(cl_bool), &val, CL_SUCCESS);
+    kernelPool[0].setExecInfo(CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM, val);
+#endif
+}
+
 /****************************************************************************
  * Tests for cl::copy
  ****************************************************************************/


### PR DESCRIPTION
- Add support for device queries
- Introduce a generic function for clSetKernelExecInfo

Support for the command queue properties will be added via #80.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>