### PR TITLE
switch from warning to pragma message for better portability

### DIFF
--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -15,4 +15,4 @@
 //
 
 #include <CL/opencl.hpp>
-#warning cl2.hpp has been renamed to opencl.hpp to make it clear that it supports all versions of OpenCL. Please include opencl.hpp directly.
+#pragma message("cl2.hpp has been renamed to opencl.hpp to make it clear that it supports all versions of OpenCL. Please include opencl.hpp directly.")


### PR DESCRIPTION
Fixes #121 

Some compiler do not support `#warning`, so switch to `#pragma message` instead.