### PR TITLE
add missing const to context properties

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -2851,7 +2851,7 @@ public:
      */
     Context(
         const vector<Device>& devices,
-        cl_context_properties* properties = NULL,
+        const cl_context_properties* properties = NULL,
         void (CL_CALLBACK * notifyFptr)(
             const char *,
             const void *,
@@ -2886,7 +2886,7 @@ public:
      */
     Context(
         const Device& device,
-        cl_context_properties* properties = NULL,
+        const cl_context_properties* properties = NULL,
         void (CL_CALLBACK * notifyFptr)(
             const char *,
             const void *,
@@ -2916,7 +2916,7 @@ public:
      */
     Context(
         cl_device_type type,
-        cl_context_properties* properties = NULL,
+        const cl_context_properties* properties = NULL,
         void (CL_CALLBACK * notifyFptr)(
             const char *,
             const void *,

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -601,6 +601,35 @@ void testContextFromType()
     clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
 }
 
+static cl_context clCreateContext_testContextNonNullProperties(
+    const cl_context_properties* properties,
+    cl_uint num_devices,
+    const cl_device_id* devices,
+    void  (CL_CALLBACK *pfn_notify) (const char *errinfo, const void  *private_info, size_t  cb, void  *user_data),
+    void  *user_data,
+    cl_int  *errcode_ret,
+    int num_calls)
+{
+    TEST_ASSERT_NOT_NULL(properties);
+    TEST_ASSERT_EQUAL(1, num_devices);
+    TEST_ASSERT_EQUAL(make_device_id(0), devices[0]);
+    return make_context(0);
+}
+
+void testContextNonNullProperties()
+{
+    clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_1);
+    clCreateContext_StubWithCallback(clCreateContext_testContextNonNullProperties);
+    clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
+
+    const cl_context_properties props[] = { 0 };
+    cl_device_id device = make_device_id(0);
+
+    cl::Context context(cl::Device(device), props);
+    TEST_ASSERT_EQUAL_PTR(make_context(0), context());
+}
+
 /****************************************************************************
  * Tests for cl::CommandQueue
  ****************************************************************************/

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -623,8 +623,10 @@ static cl_context clCreateContext_testContextNonNullProperties(
     int num_calls)
 {
     TEST_ASSERT_NOT_NULL(properties);
-    TEST_ASSERT_EQUAL(1, num_devices);
-    TEST_ASSERT_EQUAL(make_device_id(0), devices[0]);
+    TEST_ASSERT_GREATER_THAN(0, num_devices);
+    for (int i = 0; i < num_devices; i++) {
+        TEST_ASSERT_EQUAL(make_device_id(i), devices[i]);
+    }
     return make_context(0);
 }
 
@@ -637,9 +639,25 @@ void testContextWithDeviceNonNullProperties()
 
     const cl_context_properties props[] = {
         CL_CONTEXT_PLATFORM, (cl_context_properties)make_platform_id(0), 0 };
-    cl_device_id device = make_device_id(0);
+    cl::Device device = cl::Device(make_device_id(0));
 
-    cl::Context context(cl::Device(device), props);
+    cl::Context context(device, props);
+    TEST_ASSERT_EQUAL_PTR(make_context(0), context());
+}
+
+void testContextWithDevicesNonNullProperties()
+{
+    clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_1);
+    clCreateContext_StubWithCallback(clCreateContext_testContextNonNullProperties);
+    clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
+
+    const cl_context_properties props[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)make_platform_id(0), 0 };
+    cl::Device device0 = cl::Device(make_device_id(0));
+    cl::Device device1 = cl::Device(make_device_id(1));
+
+    cl::Context context({device0, device1}, props);
     TEST_ASSERT_EQUAL_PTR(make_context(0), context());
 }
 

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -601,6 +601,18 @@ void testContextFromType()
     clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
 }
 
+void testContextFromTypeNonNullProperties()
+{
+    clCreateContextFromType_StubWithCallback(clCreateContextFromType_testContextFromType);
+
+    const cl_context_properties props[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)make_platform_id(1), 0 };
+    cl::Context context(CL_DEVICE_TYPE_GPU, props);
+    TEST_ASSERT_EQUAL_PTR(make_context(0), context());
+
+    clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
+}
+
 static cl_context clCreateContext_testContextNonNullProperties(
     const cl_context_properties* properties,
     cl_uint num_devices,
@@ -616,14 +628,15 @@ static cl_context clCreateContext_testContextNonNullProperties(
     return make_context(0);
 }
 
-void testContextNonNullProperties()
+void testContextWithDeviceNonNullProperties()
 {
     clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
     clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_1);
     clCreateContext_StubWithCallback(clCreateContext_testContextNonNullProperties);
     clReleaseContext_ExpectAndReturn(make_context(0), CL_SUCCESS);
 
-    const cl_context_properties props[] = { 0 };
+    const cl_context_properties props[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)make_platform_id(0), 0 };
     cl_device_id device = make_device_id(0);
 
     cl::Context context(cl::Device(device), props);


### PR DESCRIPTION
The properties that are passed to the `cl::Context` constructor should be const to match the call to `clCreateContext` or `clCreateContextFromType`.