### PR TITLE
Add copy constructor for ImageFormat

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -2097,6 +2097,9 @@ struct ImageFormat : public cl_image_format
         image_channel_data_type = type;
     }
 
+    //! \brief Copy constructor.
+    ImageFormat(const ImageFormat &other) { *this = other; }
+
     //! \brief Assignment operator.
     ImageFormat& operator = (const ImageFormat& rhs)
     {


### PR DESCRIPTION
Recent compilers require it because ImageFormat has a user-declared
assignment operator (-Wdeprecated-copy).