### PR TITLE
Fix cl::enqueueMapSVM for cl::vector and cl::pointer

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -9320,7 +9320,7 @@ inline cl_int enqueueMapSVM(
  */
 template<typename T, class D>
 inline cl_int enqueueMapSVM(
-    cl::pointer<T, D> ptr,
+    cl::pointer<T, D> &ptr,
     cl_bool blocking,
     cl_map_flags flags,
     size_type size,
@@ -9344,7 +9344,7 @@ inline cl_int enqueueMapSVM(
  */
 template<typename T, class Alloc>
 inline cl_int enqueueMapSVM(
-    cl::vector<T, Alloc> container,
+    cl::vector<T, Alloc> &container,
     cl_bool blocking,
     cl_map_flags flags,
     const vector<Event>* events = NULL,

--- a/tests/cmock.yml
+++ b/tests/cmock.yml
@@ -7,3 +7,5 @@
     - CL_API_CALL
   :plugins:
     - :callback
+  :treat_as:
+    'void*': 'PTR'

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -2454,6 +2454,17 @@ void testEnqueueMapSVM()
 #endif
 }
 
+void testMapSVM()
+{
+#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+    std::vector<int> vec(1);
+    clRetainCommandQueue_ExpectAndReturn(make_command_queue(1), CL_SUCCESS);
+    clEnqueueSVMMap_ExpectAndReturn(make_command_queue(1), CL_TRUE, CL_MAP_READ|CL_MAP_WRITE, static_cast<void*>(vec.data()), vec.size()*sizeof(int), 0, NULL, NULL, CL_SUCCESS);
+    clReleaseCommandQueue_ExpectAndReturn(make_command_queue(1), CL_SUCCESS);
+    TEST_ASSERT_EQUAL(cl::mapSVM(vec), CL_SUCCESS);
+#endif
+}
+
 // Run after other tests to clear the default state in the header
 // using special unit test bypasses.
 // We cannot remove the once_flag, so this is a hard fix


### PR DESCRIPTION
Fix the missing reference symbol for cl::enqueueMapSVM. Otherwise vector will be coppied and enqueueMapSVM will map to a different pointer address. Added tests.