### PR TITLE
Fix Doxygen template variable

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -758,7 +758,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CLCPP_SOURCE_DIR@/include/CL/opencl.hpp
+INPUT                  = @PROJECT_SOURCE_DIR@/include/CL/opencl.hpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
The CLCPP_SOURCE_DIR CMake variable was removed when the CMake build
was recently reworked, so use PROJECT_SOURCE_DIR instead.