### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCL<sup>TM</sup> API C++ bindings
 
-Doxgen documentation for the bindings is available here:
+Doxygen documentation for the bindings is available here:
 
   http://khronosgroup.github.io/OpenCL-CLHPP/
 


### PR DESCRIPTION
Hi, Maintainers

This PR fix typo, change the word `Doxgen` to `Doxygen`. Hope this is correct.