### PR TITLE
temporarily switch back to macos-11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,18 +23,18 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-CLHPP
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-ICD-Loader
         path: external/OpenCL-ICD-Loader
@@ -183,18 +183,18 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-CLHPP
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-ICD-Loader
         path: external/OpenCL-ICD-Loader

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 jobs:
   macos-gcc:
-    runs-on: macos-latest
+    #runs-on: macos-latest
+    runs-on: macos-11 # temporary, macos-latest only supports gcc-12
     strategy:
       matrix:
         VER: [9, 11]
@@ -14,18 +15,18 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-CLHPP
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-ICD-Loader
         path: external/OpenCL-ICD-Loader

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,18 +22,18 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-CLHPP
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-ICD-Loader
         path: external/OpenCL-ICD-Loader


### PR DESCRIPTION
fixes #189 

Temporariliy (?) switches back to the older macos-11 image to unblock CI.  The macos-latest image is missing some of the compilers we currently require.  A similar fix was made to the OpenCL ICD loader in https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/198.

Also updates the checkout action to v3 to eliminate CI warnings.