### PR TITLE
Add pkg-config file for C++ API bindings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: Linux
 
 on: [push, pull_request]
 
+env:
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
+
 jobs:
   cmake-minimum:
     runs-on: ${{ matrix.OS }}
@@ -159,6 +162,14 @@ jobs:
         --build $GITHUB_WORKSPACE/build/downstream/sdk ;
         cd $GITHUB_WORKSPACE/build/downstream/sdk ;
         $CTEST_EXE --output-on-failure
+
+    - name: Test pkg-config
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+
+    - name: Test pkg-config dependency
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
 
 
 
@@ -319,3 +330,11 @@ jobs:
         cd $GITHUB_WORKSPACE/build/downstream/sdk;
         $CTEST_EXE --output-on-failure -C Release;
         $CTEST_EXE --output-on-failure -C Debug;
+
+    - name: Test pkg-config
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+
+    - name: Test pkg-config dependency
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on: [push, pull_request]
 
 env:
-  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
 
 jobs:
   cmake-minimum:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -164,7 +164,9 @@ jobs:
 
     - name: Test pkg-config
       shell: bash
-      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+      run: |
+        if [[ ! `which pkg-config` ]]; then brew install pkg-config; fi;
+        PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
 
     - name: Test pkg-config dependency
       shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: MacOS
 on: [push, pull_request]
 
 env:
-  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
 
 jobs:
   macos-gcc:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,9 @@ name: MacOS
 
 on: [push, pull_request]
 
+env:
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
+
 jobs:
   macos-gcc:
     #runs-on: macos-latest
@@ -158,3 +161,11 @@ jobs:
         cd $GITHUB_WORKSPACE/build/downstream/sdk ;
         ctest --output-on-failure -C Release ;
         ctest --output-on-failure -C Debug
+
+    - name: Test pkg-config
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+
+    - name: Test pkg-config dependency
+      shell: bash
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ install(
   EXPORT OpenCLHeadersCppTargets
 )
 
+set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(JoinPaths)
+
 include(GNUInstallDirs)
 
 install(
@@ -127,3 +130,11 @@ endif(BUILD_EXAMPLES)
 if(CLHPP_BUILD_TESTS)
   add_subdirectory(tests)
 endif(CLHPP_BUILD_TESTS)
+
+join_paths(OPENCLHPP_INCLUDEDIR_PC "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
+configure_file(OpenCL-CLHPP.pc.in OpenCL-CLHPP.pc @ONLY)
+set(pkg_config_location ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCL-CLHPP.pc
+  DESTINATION ${pkg_config_location})

--- a/OpenCL-CLHPP.pc.in
+++ b/OpenCL-CLHPP.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@OPENCLHPP_INCLUDEDIR_PC@
+
+Name: OpenCL-CLHPP
+Description: OpenCL API C++ bindings
+Requires: OpenCL-Headers
+Version: 3.0
+Cflags: -I${includedir}

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,26 @@
+# This module provides function for joining paths
+# known from from most languages
+#
+# Original license:
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Explicit permission given to distribute this module under
+# the terms of the project as described in /LICENSE.rst.
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
This implements pkg-config support for C++ bindings, which would be good to have, as hinted by https://github.com/KhronosGroup/OpenCL-Headers/issues/217

I will add a commit updating the path of the regular headers to share, but this will break the CI until https://github.com/KhronosGroup/OpenCL-Headers/pull/218 is merged.