### PR TITLE
do not explicitly include cl_ext.h

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -527,11 +527,6 @@
 #error Visual studio 2013 or another C++11-supporting compiler required
 #endif
 
-// 
-#if defined(CL_HPP_USE_CL_DEVICE_FISSION) || defined(CL_HPP_USE_CL_SUB_GROUPS_KHR)
-#include <CL/cl_ext.h>
-#endif
-
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/opencl.h>
 #else


### PR DESCRIPTION
Found during an unrelated code review: https://github.com/KhronosGroup/OpenCL-CLHPP/pull/192/files#r1105976095

Because we're already including `opencl.h` unconditionally, which unconditionally includes `cl_ext.h`, we don't need to conditionally include `cl_ext.h`.