### PR TITLE
Ignore deprecated declarations in tests also for MSVC compiler

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,8 @@ add_custom_target(
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?Clang")
     add_compile_options(-Wno-deprecated-declarations)
+elseif(MSVC)
+    add_compile_options(/wd4996)
 endif()
 
 add_definitions(-DCL_TARGET_OPENCL_VERSION=300)


### PR DESCRIPTION
This exists for GCC, so I've extended it to the Microsoft compiler so that the logs have fewer warnings.
Currently, the build log contains more than 9k warnings, and about 7k of them are about deprecation.