### PR TITLE
Fix Semaphore incomplete type

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -8948,57 +8948,13 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
         const vector<Semaphore> &sema_objects,
         const vector<cl_semaphore_payload_khr> &sema_payloads = {},
         const vector<Event>* events_wait_list = nullptr,
-        Event *event = nullptr) const
-    {
-        cl_event tmp;
-        cl_int err = CL_INVALID_OPERATION;
-
-        if (pfn_clEnqueueWaitSemaphoresKHR != nullptr) {
-            err = pfn_clEnqueueWaitSemaphoresKHR(
-                    object_,
-                    (cl_uint)sema_objects.size(),
-                    (const cl_semaphore_khr *) &sema_objects.front(),
-                    (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
-                    (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
-                    (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
-                    (event != nullptr) ? &tmp : nullptr);
-        }
-
-        detail::errHandler(err, __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR);
-
-        if (event != nullptr && err == CL_SUCCESS)
-            *event = tmp;
-
-        return err;
-    }
+        Event *event = nullptr) const;
 
     cl_int enqueueSignalSemaphore(
         const vector<Semaphore> &sema_objects,
         const vector<cl_semaphore_payload_khr>& sema_payloads = {},
         const vector<Event>* events_wait_list = nullptr,
-        Event* event = nullptr)
-    {
-        cl_event tmp;
-        cl_int err = CL_INVALID_OPERATION;
-
-        if (pfn_clEnqueueSignalSemaphoresKHR != nullptr) {
-            err = pfn_clEnqueueSignalSemaphoresKHR(
-                    object_,
-                    (cl_uint)sema_objects.size(),
-                    (const cl_semaphore_khr*) &sema_objects.front(),
-                    (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
-                    (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
-                    (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
-                    (event != nullptr) ? &tmp : nullptr);
-        }
-
-        detail::errHandler(err, __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR);
-
-        if (event != nullptr && err == CL_SUCCESS)
-            *event = tmp;
-
-        return err;
-    }
+        Event* event = nullptr);
 #endif // cl_khr_semaphore
 }; // CommandQueue
 
@@ -10512,6 +10468,63 @@ private:
 };
 
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag Semaphore::ext_init_;
+
+inline cl_int CommandQueue::enqueueWaitSemaphores(
+    const vector<Semaphore> &sema_objects,
+    const vector<cl_semaphore_payload_khr> &sema_payloads,
+    const vector<Event>* events_wait_list,
+    Event *event) const
+{
+    cl_event tmp;
+    cl_int err = CL_INVALID_OPERATION;
+
+    if (pfn_clEnqueueWaitSemaphoresKHR != nullptr) {
+        err = pfn_clEnqueueWaitSemaphoresKHR(
+                object_,
+                (cl_uint)sema_objects.size(),
+                (const cl_semaphore_khr *) &sema_objects.front(),
+                (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
+                (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
+                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
+                (event != nullptr) ? &tmp : nullptr);
+    }
+
+    detail::errHandler(err, __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR);
+
+    if (event != nullptr && err == CL_SUCCESS)
+        *event = tmp;
+
+    return err;
+}
+
+inline cl_int CommandQueue::enqueueSignalSemaphore(
+    const vector<Semaphore> &sema_objects,
+    const vector<cl_semaphore_payload_khr>& sema_payloads,
+    const vector<Event>* events_wait_list,
+    Event* event)
+{
+    cl_event tmp;
+    cl_int err = CL_INVALID_OPERATION;
+
+    if (pfn_clEnqueueSignalSemaphoresKHR != nullptr) {
+        err = pfn_clEnqueueSignalSemaphoresKHR(
+                object_,
+                (cl_uint)sema_objects.size(),
+                (const cl_semaphore_khr*) &sema_objects.front(),
+                (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
+                (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
+                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
+                (event != nullptr) ? &tmp : nullptr);
+    }
+
+    detail::errHandler(err, __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR);
+
+    if (event != nullptr && err == CL_SUCCESS)
+        *event = tmp;
+
+    return err;
+}
+
 #endif // cl_khr_semaphore
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/OpenCL-CLHPP/issues/206.

Basically, ```Semaphore``` was used in a context where its type was required to be complete.
This is easily solved by moving the ```enqueueWaitSemaphores``` function body after the ```Semaphore``` definition.

Seems like gcc/clang disagree whether this was legal. The C++20 Standard agrees with clang:

[vector.overview]
An incomplete type T may be used when instantiating vector if the allocator meets the allocator completeness requirements (16.5.3.5.1). T shall be complete before any member of the resulting specialization of vector is referenced.

At some point CI should be expanded to cover newer standards to avoid issues like this and https://github.com/KhronosGroup/OpenCL-CLHPP/pull/175