### PR TITLE
Port external memory functionality with clCreateBufferWithProperties …

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2020 The Khronos Group Inc.
+// Copyright (c) 2008-2023 The Khronos Group Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -705,7 +705,6 @@ namespace cl {
  *
  */
 namespace cl {
-    class Memory;
 
 #define CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(name) \
     using PFN_##name = name##_fn
@@ -721,6 +720,11 @@ namespace cl {
             clGetExtensionFunctionAddressForPlatform(platform, #name);  \
     }
 
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+    enum class ExternalMemoryType : cl_external_memory_handle_type_khr;
+#endif
+
+    class Memory;
     class Program;
     class Device;
     class Context;
@@ -915,7 +919,6 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 #define __CREATE_PIPE_ERR             CL_HPP_ERR_STR_(clCreatePipe)
 #define __GET_PIPE_INFO_ERR           CL_HPP_ERR_STR_(clGetPipeInfo)
 
-
 #define __RETAIN_ERR                        CL_HPP_ERR_STR_(Retain Object)
 #define __RELEASE_ERR                       CL_HPP_ERR_STR_(Release Object)
 #define __FLUSH_ERR                         CL_HPP_ERR_STR_(clFlush)
@@ -931,13 +934,18 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 #define __SET_PROGRAM_SPECIALIZATION_CONSTANT_ERR   CL_HPP_ERR_STR_(clSetProgramSpecializationConstant)
 #endif
 
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+#define __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR       CL_HPP_ERR_STR_(clEnqueueAcquireExternalMemObjectsKHR)
+#define __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR       CL_HPP_ERR_STR_(clEnqueueReleaseExternalMemObjectsKHR)
+#endif
+
 #ifdef cl_khr_semaphore
-#define __GET_SEMAPHORE_KHR_INFO_ERR                    CL_HPP_ERR_STR_(clGetSemaphoreInfoKHR)
-#define __CREATE_SEMAPHORE_KHR_WITH_PROPERTIES_ERR      CL_HPP_ERR_STR_(clCreateSemaphoreWithPropertiesKHR)
-#define __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR                CL_HPP_ERR_STR_(clEnqueueWaitSemaphoresKHR)
-#define __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR              CL_HPP_ERR_STR_(clEnqueueSignalSemaphoresKHR)
-#define __RETAIN_SEMAPHORE_KHR_ERR                      CL_HPP_ERR_STR_(clRetainSemaphoreKHR)
-#define __RELEASE_SEMAPHORE_KHR_ERR                     CL_HPP_ERR_STR_(clReleaseSemaphoreKHR)
+#define __GET_SEMAPHORE_KHR_INFO_ERR                CL_HPP_ERR_STR_(clGetSemaphoreInfoKHR)
+#define __CREATE_SEMAPHORE_KHR_WITH_PROPERTIES_ERR  CL_HPP_ERR_STR_(clCreateSemaphoreWithPropertiesKHR)
+#define __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR            CL_HPP_ERR_STR_(clEnqueueWaitSemaphoresKHR)
+#define __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR          CL_HPP_ERR_STR_(clEnqueueSignalSemaphoresKHR)
+#define __RETAIN_SEMAPHORE_KHR_ERR                  CL_HPP_ERR_STR_(clRetainSemaphoreKHR)
+#define __RELEASE_SEMAPHORE_KHR_ERR                 CL_HPP_ERR_STR_(clReleaseSemaphoreKHR)
 #endif
 
 /**
@@ -986,6 +994,14 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 
 #endif // CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 //! \endcond
+
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clEnqueueAcquireExternalMemObjectsKHR);
+CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clEnqueueReleaseExternalMemObjectsKHR);
+
+CL_HPP_DEFINE_STATIC_MEMBER_ PFN_clEnqueueAcquireExternalMemObjectsKHR pfn_clEnqueueAcquireExternalMemObjectsKHR = nullptr;
+CL_HPP_DEFINE_STATIC_MEMBER_ PFN_clEnqueueReleaseExternalMemObjectsKHR pfn_clEnqueueReleaseExternalMemObjectsKHR = nullptr;
+#endif // cl_khr_external_memory && CL_HPP_TARGET_OPENCL_VERSION >= 300
 
 #ifdef cl_khr_semaphore
 CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clCreateSemaphoreWithPropertiesKHR);
@@ -1443,6 +1459,10 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_TYPES_KHR,  cl::vector<cl_semaphore_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_TYPES_KHR,      cl::vector<cl_semaphore_type_khr>) \
 
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(F) \
+    F(cl_device_info, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>) \
+    F(cl_platform_info, CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>)
+
 #define CL_HPP_PARAM_NAME_INFO_3_0_(F) \
     F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION, cl_version) \
     F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION, cl::vector<cl_name_version>) \
@@ -1545,6 +1565,10 @@ CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(CL_HPP_DECLARE_PARAM_TRAIT
 #if defined(cl_khr_semaphore)
 CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_khr_semaphore
+
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_khr_external_memory
 
 #if defined(cl_khr_device_uuid)
 using uuid_array = array<cl_uchar, CL_UUID_SIZE_KHR>;
@@ -4053,6 +4077,41 @@ public:
         }
     }
 
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Buffer in a specified context and with specified properties.
+     *
+     *  Wraps clCreateBufferWithProperties().
+     *
+     *  \param properties Optional list of properties for the buffer object and
+                          their corresponding values. The list must not end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Buffer(
+        const Context& context,
+        vector<cl_mem_properties> properties,
+        cl_mem_flags flags,
+        size_type size,   
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        if (properties.empty())
+            object_ = ::clCreateBufferWithProperties(context(), nullptr, flags, size, host_ptr, &error);
+        else
+        {
+            properties.push_back(static_cast<cl_mem_properties>(CL_DEVICE_HANDLE_LIST_END_KHR));
+            object_ = ::clCreateBufferWithProperties(context(), properties.data(), flags, size, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_BUFFER_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif
+
     /*! \brief Constructs a Buffer in the default context.
      *
      *  Wraps clCreateBuffer().
@@ -4063,22 +4122,30 @@ public:
      *  \see Context::getDefault()
      */
     Buffer(
-         cl_mem_flags flags,
+        cl_mem_flags flags,
         size_type size,
         void* host_ptr = nullptr,
-        cl_int* err = nullptr)
-    {
-        cl_int error;
+        cl_int* err = nullptr) : Buffer(Context::getDefault(err), flags, size, host_ptr, err) { }
 
-        Context context = Context::getDefault(err);
-
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
-
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != nullptr) {
-            *err = error;
-        }
-    }
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Buffer in the default context and with specified properties.
+     *
+     *  Wraps clCreateBufferWithProperties().
+     *
+     *  \param properties Optional list of properties for the buffer object and
+                          their corresponding values. The list must not end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     * 
+     *  \see Context::getDefault()
+     */
+    Buffer(
+        vector<cl_mem_properties> properties,
+        cl_mem_flags flags,
+        size_type size,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr) : Buffer(Context::getDefault(err), properties, flags, size, host_ptr, err) { }
+#endif
 
     /*!
      * \brief Construct a Buffer from a host container via iterators.
@@ -7216,6 +7283,24 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 
 }
 
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+enum class ExternalMemoryType : cl_external_memory_handle_type_khr
+{
+    None = 0,
+    DmaBuffer = CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR,
+
+    D3D11Texture = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR,
+    D3D11TextureKMT = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR,
+
+    D3D12Heap = CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR,
+    D3D12Resource = CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR,
+
+    Opaque = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR,
+    OpaqueWin32 = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
+    OpaqueWin32_KMT = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR
+};
+#endif
+
 enum class QueueProperties : cl_command_queue_properties
 {
     None = 0,
@@ -7283,6 +7368,24 @@ private:
     static void makeDefaultProvided(const CommandQueue &c) {
         default_ = c;
     }
+
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+    static std::once_flag ext_memory_initialized_;
+
+    static void initMemoryExtension(const cl::Device& device) 
+    {
+        auto platform = device.getInfo<CL_DEVICE_PLATFORM>();
+
+        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueAcquireExternalMemObjectsKHR);
+        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueReleaseExternalMemObjectsKHR);
+
+        if ((pfn_clEnqueueAcquireExternalMemObjectsKHR == nullptr)
+            && (pfn_clEnqueueReleaseExternalMemObjectsKHR == nullptr))
+        {
+            detail::errHandler(CL_INVALID_VALUE, __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR);
+        }
+    }
+#endif // cl_khr_external_memory
 
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
@@ -8671,8 +8774,8 @@ public:
      * have completed.
      */
     cl_int enqueueMarkerWithWaitList(
-        const vector<Event> *events = 0,
-        Event *event = 0) const
+        const vector<Event> *events = nullptr,
+        Event *event = nullptr) const
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
@@ -8701,8 +8804,8 @@ public:
      * before this command to command_queue, have completed.
      */
     cl_int enqueueBarrierWithWaitList(
-        const vector<Event> *events = 0,
-        Event *event = 0) const
+        const vector<Event> *events = nullptr,
+        Event *event = nullptr) const
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
@@ -8934,21 +9037,12 @@ public:
         const vector<Event>* events = nullptr,
         Event* event = nullptr) const
     {
-        size_type elements = 0;
-        if (mem_objects != nullptr) {
-            elements = mem_objects->size();
-        }
-        vector<cl_mem> mems(elements);
-        for (unsigned int i = 0; i < elements; i++) {
-            mems[i] = ((*mem_objects)[i])();
-        }
-        
         cl_event tmp;
         cl_int err = detail::errHandler(
             ::clEnqueueNativeKernel(
                 object_, userFptr, args.first, args.second,
                 (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
-                mems.data(),
+                (mem_objects->size() > 0 ) ? reinterpret_cast<const cl_mem *>(mem_objects->data()) : nullptr,
                 (mem_locs != nullptr && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : nullptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -9137,6 +9231,66 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
         return detail::errHandler(::clFinish(object_), __FINISH_ERR);
     }
 
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+    cl_int EnqueueAcquireExternalMemObjects(
+        const vector<Memory>& mem_objects = {},
+        const vector<Event>& events_wait = {},
+        Event *event = nullptr)
+    {
+        cl_int err = CL_INVALID_OPERATION;
+        cl_event tmp;
+
+        std::call_once(ext_memory_initialized_, initMemoryExtension, this->getInfo<CL_QUEUE_DEVICE>());
+
+        if (pfn_clEnqueueAcquireExternalMemObjectsKHR)
+        {
+            err = pfn_clEnqueueAcquireExternalMemObjectsKHR(
+                object_,
+                static_cast<cl_uint>(mem_objects.size()),
+                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
+                static_cast<cl_uint>(events_wait.size()),
+                (events_wait.size() > 0) ? reinterpret_cast<const cl_event *>(events_wait.data()) : nullptr,
+                &tmp);
+        }
+
+        detail::errHandler(err, __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR);
+
+        if (event != nullptr && err == CL_SUCCESS)
+            *event = tmp;
+
+        return err;
+    }
+
+    cl_int EnqueueReleaseExternalMemObjects(
+        const vector<Memory>& mem_objects = {},
+        const vector<Event>& events_wait = {},
+        Event *event = nullptr)
+    {
+        cl_int err = CL_INVALID_OPERATION;
+        cl_event tmp;
+
+        std::call_once(ext_memory_initialized_, initMemoryExtension, this->getInfo<CL_QUEUE_DEVICE>());
+
+        if (pfn_clEnqueueReleaseExternalMemObjectsKHR)
+        {
+            err = pfn_clEnqueueReleaseExternalMemObjectsKHR(
+                object_,
+                static_cast<cl_uint>(mem_objects.size()),
+                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
+                static_cast<cl_uint>(events_wait.size()),
+                (events_wait.size() > 0) ? reinterpret_cast<const cl_event *>(events_wait.data()) : nullptr,
+                &tmp);
+        }
+
+        detail::errHandler(err, __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR);
+
+        if (event != nullptr && err == CL_SUCCESS)
+            *event = tmp;
+
+        return err;
+    }
+#endif // cl_khr_external_memory && CL_HPP_TARGET_OPENCL_VERSION >= 300
+
 #ifdef cl_khr_semaphore
     cl_int enqueueWaitSemaphores(
         const vector<Semaphore> &sema_objects,
@@ -9151,6 +9305,10 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
         Event* event = nullptr);
 #endif // cl_khr_semaphore
 }; // CommandQueue
+
+#if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300
+CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag CommandQueue::ext_memory_initialized_;
+#endif
 
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag CommandQueue::default_initialized_;
 CL_HPP_DEFINE_STATIC_MEMBER_ CommandQueue CommandQueue::default_;
@@ -10995,8 +11153,9 @@ inline cl_int CommandQueue::enqueueSignalSemaphore(
 #undef __FLUSH_ERR                         
 #undef __FINISH_ERR                        
 #undef __VECTOR_CAPACITY_ERR               
-#undef __CREATE_SUB_DEVICES_ERR            
-#undef __CREATE_SUB_DEVICES_ERR            
+#undef __CREATE_SUB_DEVICES_ERR
+#undef __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR
+#undef __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR
 #undef __ENQUEUE_MARKER_ERR                
 #undef __ENQUEUE_WAIT_FOR_EVENTS_ERR       
 #undef __ENQUEUE_BARRIER_ERR               
@@ -11021,6 +11180,7 @@ inline cl_int CommandQueue::enqueueSignalSemaphore(
 #endif //CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 
 // Extensions
+#undef CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_
 


### PR DESCRIPTION
…wrapper


Partially Closes #156
The `clCreateImageWithProperties` wrapper will be done in a separate task.

Changes description:
- I've used `if defined(cl_khr_external_memory) && CL_HPP_TARGET_OPENCL_VERSION >= 300` because [OpenCL_Ext.html](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#_dependencies_8) states:
> This extension is written against the OpenCL Specification Version 3.0.8.
> 
> Because this extension adds new properties for clCreateBufferWithProperties and clCreateImageWithProperties this extension requires OpenCL 3.0.
- `CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR` for `getInfo` from a device
- `CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR` for `getInfo` from a platform
- New type `enum class ExternalMemoryType : cl_external_memory_handle_type_khr` for above `getInfo` methods
- New constructor for `Buffer` with additional parameter `vector<cl_mem_properties> properties` wrapping the `clCreateBufferWithProperties` with and without `context`
- New `CommandQueue` methods: `EnqueueAcquireExternalMemObjects` and `EnqueueReleaseExternalMemObjects`
- Minor improvements and enhancements