### PR TITLE
fix CI testing for MacOS and Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,175 +6,6 @@ env:
   OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig:${{ github.workspace }}/external/OpenCL-ICD-Loader/install/lib/pkgconfig
 
 jobs:
-  cmake-minimum:
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      matrix:
-        OS: [ubuntu-18.04]
-        VER: [7, 8] # clang-8, clang-10
-        EXT: [ON, OFF]
-        GEN: [Unix Makefiles]
-        CONFIG: [Debug, Release]
-        STD: [11, 14]
-        BIN: [64] # Temporarily disable cross-compilation (will need toolchain files)
-        CMAKE: [3.1.3]
-    env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
-      CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
-      CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
-
-
-    steps:
-    - name: Checkout OpenCL-CLHPP
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v3
-      with:
-        repository: KhronosGroup/OpenCL-Headers
-        path: external/OpenCL-Headers
-
-    - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v3
-      with:
-        repository: KhronosGroup/OpenCL-ICD-Loader
-        path: external/OpenCL-ICD-Loader
-
-    - name: Create Build Environment
-      run: sudo apt-get update -q;
-        if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
-        sudo apt install gcc-${{matrix.VER}} g++-${{matrix.VER}}; 
-        if [[ "${{matrix.BIN}}" == "32" ]];
-        then sudo apt install gcc-${COMPILER_VER}-multilib;
-        fi;
-        mkdir -p /opt/Kitware/CMake;
-        wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
-        mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
-      # Install Ninja only if it's the selected generator and it's not available.
-
-    - name: Build & install OpenCL-Headers
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=gcc-${{matrix.VER}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B$GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        -H$GITHUB_WORKSPACE/external/OpenCL-Headers &&
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        --target install
-        --
-        -j`nproc`
-
-    - name: Build & install OpenCL-ICD-Loader
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=gcc-${{matrix.VER}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/install
-        -B$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/build
-        -H$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader &&
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/build
-        --target install
-        --
-        -j`nproc`
-
-    - name: Configure
-      shell: bash
-      # no -Werror during configuration because:
-      # warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
-      # warning: unused parameter [-Wunused-parameter]
-      run: 
-        $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D BUILD_TESTS=ON
-        -D BUILD_EXAMPLES=ON
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
-        -D CMAKE_CXX_STANDARD=${{matrix.STD}}
-        -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/install"
-        -B$GITHUB_WORKSPACE/build
-        -H$GITHUB_WORKSPACE
-
-    - name: Build
-      shell: bash
-      run: $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build
-        --
-        -j`nproc`
-
-    - name: Test
-      working-directory: ${{runner.workspace}}/OpenCL-CLHPP/build
-      shell: bash
-      run: $CTEST_EXE --output-on-failure --parallel `nproc`
-
-    - name: Install
-      shell: bash
-      run: $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build
-        --target install
-        --
-        -j`nproc`
-
-    - name: "Consume (standalone): Configure/Build/Test"
-      shell: bash
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
-        -D CMAKE_CXX_STANDARD=${{matrix.STD}}
-        -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/install;$GITHUB_WORKSPACE/install"
-        -B$GITHUB_WORKSPACE/build/downstream/bare
-        -H$GITHUB_WORKSPACE/tests/pkgconfig/bare ;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build/downstream/bare ;
-        cd $GITHUB_WORKSPACE/build/downstream/bare ;
-        $CTEST_EXE --output-on-failure
-
-    - name: "Consume (SDK): Configure/Build/Test"
-      shell: bash
-      run: $CMAKE_EXE -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL ;
-        echo -e 'include("/home/runner/work/OpenCL-CLHPP/OpenCL-CLHPP/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("/home/runner/work/OpenCL-CLHPP/OpenCL-CLHPP/external/OpenCL-ICD-Loader/install/share/cmake/OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLHeadersCpp/OpenCLHeadersCppTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
-        $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
-        -D CMAKE_CXX_STANDARD=${{matrix.STD}}
-        -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install"
-        -B$GITHUB_WORKSPACE/build/downstream/sdk
-        -H$GITHUB_WORKSPACE/tests/pkgconfig/sdk ;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build/downstream/sdk ;
-        cd $GITHUB_WORKSPACE/build/downstream/sdk ;
-        $CTEST_EXE --output-on-failure
-
-    - name: Test pkg-config
-      shell: bash
-      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
-
-    - name: Test pkg-config dependency
-      shell: bash
-      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL-CLHPP --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
-
-
-
-
-
   cmake-latest:
     runs-on: ${{ matrix.OS }}
     strategy:
@@ -220,11 +51,11 @@ jobs:
         mkdir -p /opt/Kitware/CMake;
         wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
         mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
-      # Install Ninja only if it's the selected generator and it's not available.
 
     - name: Build & install OpenCL-Headers
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
+        -D BUILD_TESTING=OFF
         -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
         -D CMAKE_C_COMPILER=gcc-${{matrix.VER}}
         -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
@@ -241,6 +72,7 @@ jobs:
     - name: Build & install OpenCL-ICD-Loader
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
+        -D BUILD_TESTING=OFF
         -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
         -D CMAKE_C_COMPILER=gcc-${{matrix.VER}}
         -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
@@ -262,7 +94,7 @@ jobs:
       # warning: unused parameter [-Wunused-parameter]
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
-        -D BUILD_TESTS=ON
+        -D BUILD_TESTING=ON
         -D BUILD_EXAMPLES=ON
         -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,11 +39,12 @@ jobs:
         cmake -E make_directory $GITHUB_WORKSPACE/build;
         cmake -E make_directory $GITHUB_WORKSPACE/install;
         if [[ "${{matrix.GEN}}" == "Ninja Multi-Config" && ! `which ninja` ]]; then brew install ninja; fi;
-        # Install Ninja only if it's the selected generator and it's not available.
+        if [[ ! `which /usr/local/bin/gcc-${{matrix.VER}}` ]]; then brew install gcc@${{matrix.VER}}; fi;
 
     - name: Build & install OpenCL-Headers
       run: cmake
         -G "${{matrix.GEN}}"
+        -D BUILD_TESTING=OFF
         -D CMAKE_C_FLAGS="-w"
         -D CMAKE_C_COMPILER=/usr/local/bin/gcc-${{matrix.VER}}
         -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
@@ -63,6 +64,7 @@ jobs:
     - name: Build & install OpenCL-ICD-Loader
       run: cmake
         -G "${{matrix.GEN}}"
+        -D BUILD_TESTING=OFF
         -D CMAKE_C_FLAGS="-w -m64"
         -D CMAKE_C_COMPILER=/usr/local/bin/gcc-${{matrix.VER}}
         -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         set C_FLAGS="/w"
         if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
+        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D BUILD_TESTING=OFF -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
         %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install --config Release -- /verbosity:minimal /maxCpuCount /noLogo
 
     - name: Build & install OpenCL-Headers (Ninja Multi-Config)
@@ -69,7 +69,7 @@ jobs:
         if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
         if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
+        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D BUILD_TESTING=OFF -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
         %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install -- -j%NUMBER_OF_PROCESSORS%
 
     - name: Build & install OpenCL-ICD-Loader (MSBuild)
@@ -78,7 +78,7 @@ jobs:
       run: |
         set C_FLAGS="/w"
         if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader -B %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\build
+        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D BUILD_TESTING=OFF -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader -B %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\build
         %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-ICD-Loader/build --target install --config Release -- /verbosity:minimal /maxCpuCount /noLogo
 
     - name: Build & install OpenCL-ICD-Loader (Ninja Multi-Config)
@@ -91,7 +91,7 @@ jobs:
         if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
         if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader -B %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\build
+        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D BUILD_TESTING=OFF -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader -B %GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\build
         %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-ICD-Loader/build --target install --config Release -- -j%NUMBER_OF_PROCESSORS%
 
     - name: Configure (MSBuild)


### PR DESCRIPTION
This PR applies the same CI fixes from other repos to OpenCL-CLHPP:

- It removes the Ubuntu 18.04 configs because the Ubuntu 18.04 runner is deprecated.
- Explicitly installs gcc-9 on MacOS since it is no longer installed by default.
- Removes testing from OpenCL-Headers and OpenCL-ICD-Loader to speed up the builds.

I haven't moved any of the testing for Ubuntu 18.04 to Ubuntu 20.04 - this can be done in a separate PR.