### PR TITLE
Unit tests for cl::Semaphore

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1520,7 +1520,12 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr)
 
 #define CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(F) \
+    F(cl_semaphore_info_khr, CL_SEMAPHORE_CONTEXT_KHR, cl::Context) \
+    F(cl_semaphore_info_khr, CL_SEMAPHORE_REFERENCE_COUNT_KHR, cl_uint) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_PROPERTIES_KHR, cl::vector<cl_semaphore_properties_khr>) \
+    F(cl_semaphore_info_khr, CL_SEMAPHORE_TYPE_KHR, cl_semaphore_type_khr) \
+    F(cl_semaphore_info_khr, CL_SEMAPHORE_PAYLOAD_KHR, cl_semaphore_payload_khr) \
+    F(cl_semaphore_info_khr, CL_DEVICE_HANDLE_LIST_KHR, cl::vector<cl::Device>) \
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_TYPES_KHR,  cl::vector<cl_semaphore_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_TYPES_KHR,      cl::vector<cl_semaphore_type_khr>) \
 
@@ -10447,7 +10452,7 @@ public:
         }
 
         return detail::errHandler(
-            detail::getInfo(&pfn_clGetSemaphoreInfoKHR, object_, name, param),
+            detail::getInfo(pfn_clGetSemaphoreInfoKHR, object_, name, param),
             __GET_SEMAPHORE_KHR_INFO_ERR);
     }
     template <cl_semaphore_info_khr name> typename

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3431,6 +3431,7 @@ void testMoveConstructSemaphoreNonNull(void) {}
 void testMoveConstructSemaphoreNull(void) {}
 #endif
 
+#if defined(cl_khr_semaphore)
 static cl_int clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores(
     cl_command_queue command_queue,
     cl_uint num_sema_objects,
@@ -3460,7 +3461,6 @@ static cl_int clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores(
 
 void testEnqueueWaitSemaphores(void)
 {
-#if defined(cl_khr_semaphore)
     clEnqueueWaitSemaphoresKHR_StubWithCallback(clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores);
 
     VECTOR_CLASS<cl::Semaphore> sema_objects;
@@ -3475,7 +3475,6 @@ void testEnqueueWaitSemaphores(void)
     // prevent destructor from interfering with the test
     event() = nullptr;
     sema_objects[0]() = nullptr;
-#endif
 }
 
 static cl_int clEnqueueSignalSemaphoresKHR_testEnqueueSignalSemaphores(
@@ -3507,7 +3506,6 @@ static cl_int clEnqueueSignalSemaphoresKHR_testEnqueueSignalSemaphores(
 
 void testEnqueueSignalSemaphores(void)
 {
-#if defined(cl_khr_semaphore)
     clEnqueueSignalSemaphoresKHR_StubWithCallback(clEnqueueSignalSemaphoresKHR_testEnqueueSignalSemaphores);
 
     VECTOR_CLASS<cl::Semaphore> sema_objects;
@@ -3522,7 +3520,6 @@ void testEnqueueSignalSemaphores(void)
     // prevent destructor from interfering with the test
     event() = nullptr;
     sema_objects[0]() = nullptr;
-#endif
 }
 
 cl_semaphore_khr clCreateSemaphoreWithProperties_testSemaphoreWithProperties(
@@ -3542,7 +3539,6 @@ cl_semaphore_khr clCreateSemaphoreWithProperties_testSemaphoreWithProperties(
 
 void testSemaphoreWithProperties(void)
 {
-#if defined(cl_khr_semaphore)
     cl_device_id expected_device = make_device_id(0);
     int device_refcount = 1;
 
@@ -3562,7 +3558,6 @@ void testSemaphoreWithProperties(void)
 
     // prevent destructor from interfering with the test
     sem() = nullptr;
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetContext(
@@ -3586,7 +3581,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetContext(
 
 void testSemaphoreGetInfoContext(void)
 {
-#if defined(cl_khr_semaphore)
     cl_context expected_context = make_context(0);
     int context_refcount = 1;
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetContext);
@@ -3598,7 +3592,6 @@ void testSemaphoreGetInfoContext(void)
 
     TEST_ASSERT_EQUAL(CL_SUCCESS, err);
     TEST_ASSERT_EQUAL_PTR(make_context(0), ctx());
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetReferenceCount(
@@ -3622,7 +3615,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetReferenceCount(
 
 void testSemaphoreGetInfoReferenceCount(void)
 {
-#if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetReferenceCount);
 
     cl_int err = CL_INVALID_OPERATION;
@@ -3631,7 +3623,6 @@ void testSemaphoreGetInfoReferenceCount(void)
 
     TEST_ASSERT_EQUAL(CL_SUCCESS, err);
     TEST_ASSERT_EQUAL(1, ret);
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetProperties(
@@ -3660,7 +3651,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetProperties(
 
 void testSemaphoreGetInfoProperties(void)
 {
-#if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetProperties);
 
     cl_int err = CL_INVALID_OPERATION;
@@ -3671,7 +3661,6 @@ void testSemaphoreGetInfoProperties(void)
     TEST_ASSERT_EQUAL(2, ret.size());
     TEST_ASSERT_EQUAL(CL_SEMAPHORE_TYPE_KHR, ret[0]);
     TEST_ASSERT_EQUAL(CL_SEMAPHORE_TYPE_BINARY_KHR, ret[1]);
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetType(
@@ -3695,7 +3684,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetType(
 
 void testSemaphoreGetInfoType(void)
 {
-#if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetType);
 
     cl_int err = CL_INVALID_OPERATION;
@@ -3704,7 +3692,6 @@ void testSemaphoreGetInfoType(void)
 
     TEST_ASSERT_EQUAL(CL_SUCCESS, err);
     TEST_ASSERT_EQUAL(CL_SEMAPHORE_TYPE_BINARY_KHR, ret);
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetPayload(
@@ -3728,7 +3715,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetPayload(
 
 void testSemaphoreGetInfoPayload(void)
 {
-#if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetPayload);
 
     cl_int err = CL_INVALID_OPERATION;
@@ -3737,7 +3723,6 @@ void testSemaphoreGetInfoPayload(void)
 
     TEST_ASSERT_EQUAL(CL_SUCCESS, err);
     TEST_ASSERT_EQUAL(1, ret);
-#endif
 }
 
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetDevices(
@@ -3765,7 +3750,6 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetDevices(
 
 void testSemaphoreGetInfoDevicesList(void)
 {
-#if defined(cl_khr_semaphore)
     cl_device_id expected_devices[] = {make_device_id(0), make_device_id(1)};
     int device_refcounts[] = {1, 1};
 
@@ -3783,27 +3767,36 @@ void testSemaphoreGetInfoDevicesList(void)
     TEST_ASSERT_EQUAL(2, ret.size());
     TEST_ASSERT_EQUAL(make_device_id(0), ret[0]());
     TEST_ASSERT_EQUAL(make_device_id(1), ret[1]());
-#endif
 }
 
 void testSemaphoreRetain(void)
 {
-#if defined(cl_khr_semaphore)
     clRetainSemaphoreKHR_ExpectAndReturn(semaphorePool[0](), CL_SUCCESS);
 
     cl_int status = semaphorePool[0].retain();
     TEST_ASSERT_EQUAL(CL_SUCCESS, status);
-#endif
 }
 
 void testSemaphoreRelease(void)
 {
-#if defined(cl_khr_semaphore)
     clReleaseSemaphoreKHR_ExpectAndReturn(semaphorePool[0](), CL_SUCCESS);
 
     cl_int status = semaphorePool[0].release();
     TEST_ASSERT_EQUAL(CL_SUCCESS, status);
-#endif
 }
+
+#else
+void testEnqueueWaitSemaphores(void) {}
+void testEnqueueSignalSemaphores(void) {}
+void testSemaphoreWithProperties(void) {}
+void testSemaphoreGetInfoContext(void) {}
+void testSemaphoreGetInfoReferenceCount(void) {}
+void testSemaphoreGetInfoProperties(void) {}
+void testSemaphoreGetInfoType(void) {}
+void testSemaphoreGetInfoPayload(void) {}
+void testSemaphoreGetInfoDevicesList(void) {}
+void testSemaphoreRetain(void) {}
+void testSemaphoreRelease(void) {}
+#endif // cl_khr_semaphore
 
 } // extern "C"

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3419,16 +3419,16 @@ void testCommandBufferInfoKHRCommandQueues()
  * Tests for cl::Semaphore
  ****************************************************************************/
 #if defined(cl_khr_semaphore)
-void testMoveAssignSemaphoreNonNull();
-void testMoveAssignSemaphoreNull();
-void testMoveConstructSemaphoreNonNull();
-void testMoveConstructSemaphoreNull();
+void testMoveAssignSemaphoreNonNull(void);
+void testMoveAssignSemaphoreNull(void);
+void testMoveConstructSemaphoreNonNull(void);
+void testMoveConstructSemaphoreNull(void);
 MAKE_MOVE_TESTS(Semaphore, make_semaphore_khr, clReleaseSemaphoreKHR, semaphorePool);
 #else
-void testMoveAssignSemaphoreNonNull() {}
-void testMoveAssignSemaphoreNull() {}
-void testMoveConstructSemaphoreNonNull() {}
-void testMoveConstructSemaphoreNull() {}
+void testMoveAssignSemaphoreNonNull(void) {}
+void testMoveAssignSemaphoreNull(void) {}
+void testMoveConstructSemaphoreNonNull(void) {}
+void testMoveConstructSemaphoreNull(void) {}
 #endif
 
 static cl_int clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores(
@@ -3458,7 +3458,7 @@ static cl_int clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores(
     return CL_SUCCESS;
 }
 
-void testEnqueueWaitSemaphores()
+void testEnqueueWaitSemaphores(void)
 {
 #if defined(cl_khr_semaphore)
     clEnqueueWaitSemaphoresKHR_StubWithCallback(clEnqueueWaitSemaphoresKHR_testEnqueueWaitSemaphores);
@@ -3505,7 +3505,7 @@ static cl_int clEnqueueSignalSemaphoresKHR_testEnqueueSignalSemaphores(
     return CL_SUCCESS;
 }
 
-void testEnqueueSignalSemaphores()
+void testEnqueueSignalSemaphores(void)
 {
 #if defined(cl_khr_semaphore)
     clEnqueueSignalSemaphoresKHR_StubWithCallback(clEnqueueSignalSemaphoresKHR_testEnqueueSignalSemaphores);
@@ -3540,7 +3540,7 @@ cl_semaphore_khr clCreateSemaphoreWithProperties_testSemaphoreWithProperties(
     return make_semaphore_khr(1);
 }
 
-void testSemaphoreWithProperties()
+void testSemaphoreWithProperties(void)
 {
 #if defined(cl_khr_semaphore)
     cl_device_id expected_device = make_device_id(0);
@@ -3548,7 +3548,7 @@ void testSemaphoreWithProperties()
 
     clGetContextInfo_StubWithCallback(clGetContextInfo_device);
     clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
-    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_3_0);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_1);
     prepare_deviceRefcounts(1, &expected_device, &device_refcount);
 
     clCreateSemaphoreWithPropertiesKHR_StubWithCallback(clCreateSemaphoreWithProperties_testSemaphoreWithProperties);
@@ -3584,7 +3584,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetContext(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoContext()
+void testSemaphoreGetInfoContext(void)
 {
 #if defined(cl_khr_semaphore)
     cl_context expected_context = make_context(0);
@@ -3620,7 +3620,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetReferenceCount(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoReferenceCount()
+void testSemaphoreGetInfoReferenceCount(void)
 {
 #if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetReferenceCount);
@@ -3658,7 +3658,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetProperties(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoProperties()
+void testSemaphoreGetInfoProperties(void)
 {
 #if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetProperties);
@@ -3693,7 +3693,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetType(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoType()
+void testSemaphoreGetInfoType(void)
 {
 #if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetType);
@@ -3726,7 +3726,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetPayload(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoPayload()
+void testSemaphoreGetInfoPayload(void)
 {
 #if defined(cl_khr_semaphore)
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetPayload);
@@ -3763,14 +3763,14 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetDevices(
     return CL_SUCCESS;
 }
 
-void testSemaphoreGetInfoDevicesList()
+void testSemaphoreGetInfoDevicesList(void)
 {
 #if defined(cl_khr_semaphore)
     cl_device_id expected_devices[] = {make_device_id(0), make_device_id(1)};
     int device_refcounts[] = {1, 1};
 
     clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
-    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_3_0);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_1_1);
     prepare_deviceRefcounts(ARRAY_SIZE(expected_devices), expected_devices, device_refcounts);
 
     clGetSemaphoreInfoKHR_StubWithCallback(clGetSemaphoreInfoKHR_testSemaphoreGetDevices);
@@ -3786,7 +3786,7 @@ void testSemaphoreGetInfoDevicesList()
 #endif
 }
 
-void testSemaphoreRetain()
+void testSemaphoreRetain(void)
 {
 #if defined(cl_khr_semaphore)
     clRetainSemaphoreKHR_ExpectAndReturn(semaphorePool[0](), CL_SUCCESS);
@@ -3796,7 +3796,7 @@ void testSemaphoreRetain()
 #endif
 }
 
-void testSemaphoreRelease()
+void testSemaphoreRelease(void)
 {
 #if defined(cl_khr_semaphore)
     clReleaseSemaphoreKHR_ExpectAndReturn(semaphorePool[0](), CL_SUCCESS);


### PR DESCRIPTION
Fix pointer param for clGetSemaphoreInfoKHR.
Add more params supported by clGetSemaphoreInfoKHR.