### PR TITLE
wrappers for clEnqueueSVMMemFill and clEnqueueSVMMemcpy

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2023 The Khronos Group Inc.
+// Copyright (c) 2008-2020 The Khronos Group Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -705,6 +705,7 @@ namespace cl {
  *
  */
 namespace cl {
+    class Memory;
 
 #define CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(name) \
     using PFN_##name = name##_fn
@@ -720,11 +721,6 @@ namespace cl {
             clGetExtensionFunctionAddressForPlatform(platform, #name);  \
     }
 
-#ifdef cl_khr_external_memory
-    enum class ExternalMemoryType : cl_external_memory_handle_type_khr;
-#endif
-
-    class Memory;
     class Program;
     class Device;
     class Context;
@@ -905,6 +901,10 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 #define __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR  CL_HPP_ERR_STR_(clEnqueueCopyBufferToImage)
 #define __ENQUEUE_MAP_BUFFER_ERR            CL_HPP_ERR_STR_(clEnqueueMapBuffer)
 #define __ENQUEUE_MAP_IMAGE_ERR             CL_HPP_ERR_STR_(clEnqueueMapImage)
+#define __ENQUEUE_MAP_SVM_ERR               CL_HPP_ERR_STR_(clEnqueueSVMMap)
+#define __ENQUEUE_FILL_SVM_ERR              CL_HPP_ERR_STR_(clEnqueueSVMMemFill)
+#define __ENQUEUE_COPY_SVM_ERR              CL_HPP_ERR_STR_(clEnqueueSVMMemcpy)
+#define __ENQUEUE_UNMAP_SVM_ERR              CL_HPP_ERR_STR_(clEnqueueSVMUnmap)
 #define __ENQUEUE_UNMAP_MEM_OBJECT_ERR      CL_HPP_ERR_STR_(clEnqueueUnMapMemObject)
 #define __ENQUEUE_NDRANGE_KERNEL_ERR        CL_HPP_ERR_STR_(clEnqueueNDRangeKernel)
 #define __ENQUEUE_NATIVE_KERNEL             CL_HPP_ERR_STR_(clEnqueueNativeKernel)
@@ -923,6 +923,7 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 #define __CREATE_PIPE_ERR             CL_HPP_ERR_STR_(clCreatePipe)
 #define __GET_PIPE_INFO_ERR           CL_HPP_ERR_STR_(clGetPipeInfo)
 
+
 #define __RETAIN_ERR                        CL_HPP_ERR_STR_(Retain Object)
 #define __RELEASE_ERR                       CL_HPP_ERR_STR_(Release Object)
 #define __FLUSH_ERR                         CL_HPP_ERR_STR_(clFlush)
@@ -938,18 +939,13 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 #define __SET_PROGRAM_SPECIALIZATION_CONSTANT_ERR   CL_HPP_ERR_STR_(clSetProgramSpecializationConstant)
 #endif
 
-#ifdef cl_khr_external_memory
-#define __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR       CL_HPP_ERR_STR_(clEnqueueAcquireExternalMemObjectsKHR)
-#define __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR       CL_HPP_ERR_STR_(clEnqueueReleaseExternalMemObjectsKHR)
-#endif
-
 #ifdef cl_khr_semaphore
-#define __GET_SEMAPHORE_KHR_INFO_ERR                CL_HPP_ERR_STR_(clGetSemaphoreInfoKHR)
-#define __CREATE_SEMAPHORE_KHR_WITH_PROPERTIES_ERR  CL_HPP_ERR_STR_(clCreateSemaphoreWithPropertiesKHR)
-#define __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR            CL_HPP_ERR_STR_(clEnqueueWaitSemaphoresKHR)
-#define __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR          CL_HPP_ERR_STR_(clEnqueueSignalSemaphoresKHR)
-#define __RETAIN_SEMAPHORE_KHR_ERR                  CL_HPP_ERR_STR_(clRetainSemaphoreKHR)
-#define __RELEASE_SEMAPHORE_KHR_ERR                 CL_HPP_ERR_STR_(clReleaseSemaphoreKHR)
+#define __GET_SEMAPHORE_KHR_INFO_ERR                    CL_HPP_ERR_STR_(clGetSemaphoreInfoKHR)
+#define __CREATE_SEMAPHORE_KHR_WITH_PROPERTIES_ERR      CL_HPP_ERR_STR_(clCreateSemaphoreWithPropertiesKHR)
+#define __ENQUEUE_WAIT_SEMAPHORE_KHR_ERR                CL_HPP_ERR_STR_(clEnqueueWaitSemaphoresKHR)
+#define __ENQUEUE_SIGNAL_SEMAPHORE_KHR_ERR              CL_HPP_ERR_STR_(clEnqueueSignalSemaphoresKHR)
+#define __RETAIN_SEMAPHORE_KHR_ERR                      CL_HPP_ERR_STR_(clRetainSemaphoreKHR)
+#define __RELEASE_SEMAPHORE_KHR_ERR                     CL_HPP_ERR_STR_(clReleaseSemaphoreKHR)
 #endif
 #if defined(cl_khr_command_buffer)
 #define __CREATE_COMMAND_BUFFER_KHR_ERR             CL_HPP_ERR_STR_(clCreateCommandBufferKHR)
@@ -1017,14 +1013,6 @@ static inline cl_int errHandler (cl_int err, const char * errStr = nullptr)
 
 #endif // CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 //! \endcond
-
-#ifdef cl_khr_external_memory
-CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clEnqueueAcquireExternalMemObjectsKHR);
-CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clEnqueueReleaseExternalMemObjectsKHR);
-
-CL_HPP_DEFINE_STATIC_MEMBER_ PFN_clEnqueueAcquireExternalMemObjectsKHR pfn_clEnqueueAcquireExternalMemObjectsKHR = nullptr;
-CL_HPP_DEFINE_STATIC_MEMBER_ PFN_clEnqueueReleaseExternalMemObjectsKHR pfn_clEnqueueReleaseExternalMemObjectsKHR = nullptr;
-#endif // cl_khr_external_memory
 
 #ifdef cl_khr_semaphore
 CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(clCreateSemaphoreWithPropertiesKHR);
@@ -1524,10 +1512,6 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_TYPES_KHR,  cl::vector<cl_semaphore_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_TYPES_KHR,      cl::vector<cl_semaphore_type_khr>) \
 
-#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(F) \
-    F(cl_device_info, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>) \
-    F(cl_platform_info, CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>)
-
 #define CL_HPP_PARAM_NAME_INFO_3_0_(F) \
     F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION, cl_version) \
     F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION, cl::vector<cl_name_version>) \
@@ -1630,10 +1614,6 @@ CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(CL_HPP_DECLARE_PARAM_TRAIT
 #if defined(cl_khr_semaphore)
 CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_khr_semaphore
-
-#ifdef cl_khr_external_memory
-CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(CL_HPP_DECLARE_PARAM_TRAITS_)
-#endif // cl_khr_external_memory
 
 #if defined(cl_khr_device_uuid)
 using uuid_array = array<cl_uchar, CL_UUID_SIZE_KHR>;
@@ -3888,7 +3868,8 @@ public:
      */
     pointer allocate(
         size_type size,
-        typename cl::SVMAllocator<void, SVMTrait>::const_pointer = 0)
+        typename cl::SVMAllocator<void, SVMTrait>::const_pointer = 0,
+        cl_bool map=true)
     {
         // Allocate memory with default alignment matching the size of the type
         void* voidPointer =
@@ -3907,7 +3888,7 @@ public:
 #endif // #if defined(CL_HPP_ENABLE_EXCEPTIONS)
 
         // If allocation was coarse-grained then map it
-        if (!(SVMTrait::getSVMMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
+        if (map && !(SVMTrait::getSVMMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
             cl_int err = enqueueMapSVM(retValue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, size*sizeof(T));
             if (err != CL_SUCCESS) {
                 std::bad_alloc excep;
@@ -4113,43 +4094,6 @@ public:
         }
     }
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 300
-    /*! \brief Constructs a Buffer in a specified context and with specified properties.
-     *
-     *  Wraps clCreateBufferWithProperties().
-     *
-     *  \param properties Optional list of properties for the buffer object and
-     *                    their corresponding values. The non-empty list must
-     *                    end with 0. 
-     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
-     *                  specified. Note alignment & exclusivity requirements.
-     */
-    Buffer(
-        const Context& context,
-        const vector<cl_mem_properties>& properties,
-        cl_mem_flags flags,
-        size_type size,
-        void* host_ptr = nullptr,
-        cl_int* err = nullptr)
-    {
-        cl_int error;
-
-        if (properties.empty()) {
-            object_ = ::clCreateBufferWithProperties(context(), nullptr, flags,
-                                                     size, host_ptr, &error);
-        }
-        else {
-            object_ = ::clCreateBufferWithProperties(
-                context(), properties.data(), flags, size, host_ptr, &error);
-        }
-
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != nullptr) {
-            *err = error;
-        }
-    }
-#endif
-
     /*! \brief Constructs a Buffer in the default context.
      *
      *  Wraps clCreateBuffer().
@@ -4160,31 +4104,22 @@ public:
      *  \see Context::getDefault()
      */
     Buffer(
-        cl_mem_flags flags,
+         cl_mem_flags flags,
         size_type size,
         void* host_ptr = nullptr,
-        cl_int* err = nullptr) : Buffer(Context::getDefault(err), flags, size, host_ptr, err) { }
+        cl_int* err = nullptr)
+    {
+        cl_int error;
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 300
-    /*! \brief Constructs a Buffer in the default context and with specified properties.
-     *
-     *  Wraps clCreateBufferWithProperties().
-     *
-     *  \param properties Optional list of properties for the buffer object and
-     *                    their corresponding values. The non-empty list must
-     *                    end with 0. 
-     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
-     *                  specified. Note alignment & exclusivity requirements.
-     * 
-     *  \see Context::getDefault()
-     */
-    Buffer(
-        const vector<cl_mem_properties>& properties,
-        cl_mem_flags flags,
-        size_type size,
-        void* host_ptr = nullptr,
-        cl_int* err = nullptr) : Buffer(Context::getDefault(err), properties, flags, size, host_ptr, err) { }
-#endif
+        Context context = Context::getDefault(err);
+
+        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_BUFFER_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
 
     /*!
      * \brief Construct a Buffer from a host container via iterators.
@@ -6841,25 +6776,6 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 
 }
 
-#ifdef cl_khr_external_memory
-enum class ExternalMemoryType : cl_external_memory_handle_type_khr
-{
-    None = 0,
-
-    OpaqueFd = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR,
-    OpaqueWin32 = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
-    OpaqueWin32Kmt = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR,
-
-    D3D11Texture = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR,
-    D3D11TextureKmt = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR,
-
-    D3D12Heap = CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR,
-    D3D12Resource = CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR,
-
-    DmaBuf = CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR,
-};
-#endif
-
 enum class QueueProperties : cl_command_queue_properties
 {
     None = 0,
@@ -6927,24 +6843,6 @@ private:
     static void makeDefaultProvided(const CommandQueue &c) {
         default_ = c;
     }
-
-#ifdef cl_khr_external_memory
-    static std::once_flag ext_memory_initialized_;
-
-    static void initMemoryExtension(const cl::Device& device) 
-    {
-        auto platform = device.getInfo<CL_DEVICE_PLATFORM>();
-
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueAcquireExternalMemObjectsKHR);
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueReleaseExternalMemObjectsKHR);
-
-        if ((pfn_clEnqueueAcquireExternalMemObjectsKHR == nullptr)
-            && (pfn_clEnqueueReleaseExternalMemObjectsKHR == nullptr))
-        {
-            detail::errHandler(CL_INVALID_VALUE, __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR);
-        }
-    }
-#endif // cl_khr_external_memory
 
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
@@ -8111,7 +8009,162 @@ public:
     }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /**
+
+        /**
+        * Enqueues a command that copies a region of memory from the source pointer to the destination pointer.
+        * This function is specifically for transferring data between the host and a coarse-grained SVM buffer.
+        */
+        template<typename T>
+        cl_int enqueueMemcpySVM(
+                T *dst_ptr,
+                const T *src_ptr,
+                cl_bool blocking,
+                size_type size,
+                const vector<Event> *events = nullptr,
+                Event *event = nullptr) const {
+            cl_event tmp;
+            cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+                    object_, blocking, static_cast<void *>(dst_ptr), static_cast<const void *>(src_ptr), size,
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != nullptr) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+
+        /**
+        *Enqueues a command that will copy data from one coarse-grained SVM buffer to another.
+        *This function takes two cl::pointer instances representing the destination and source buffers.
+        */
+        template<typename T, class D>
+        cl_int enqueueMemcpySVM(
+                cl::pointer<T, D> &dst_ptr,
+                const cl::pointer<T, D> &src_ptr,
+                cl_bool blocking,
+                size_type size,
+                const vector<Event> *events = nullptr,
+                Event *event = nullptr) const {
+            cl_event tmp;
+            cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+                    object_, blocking, static_cast<void *>(dst_ptr.get()), static_cast<const void *>(src_ptr.get()),
+                    size,
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != nullptr) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+
+        /**
+        * Enqueues a command that will allow the host to update a region of a coarse-grained SVM buffer.
+        * This variant takes a cl::vector instance.
+        */
+        template<typename T, class Alloc>
+        cl_int enqueueMemcpySVM(
+                cl::vector<T, Alloc> &dst_container,
+                const cl::vector<T, Alloc> &src_container,
+                cl_bool blocking,
+                const vector<Event> *events = nullptr,
+                Event *event = nullptr) const {
+            cl_event tmp;
+            if(src_container.size() != dst_container.size()){
+                return detail::errHandler(CL_INVALID_VALUE,__ENQUEUE_COPY_SVM_ERR);
+            }
+            cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+                    object_, blocking, static_cast<void *>(dst_container.data()),
+                    static_cast<const void *>(src_container.data()),
+                    dst_container.size() * sizeof(T),
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != NULL) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+
+        /**
+        * Enqueues a command to fill a SVM buffer with a pattern.
+        *
+        */
+        template<typename T, typename PatternType>
+        cl_int enqueueMemFillSVM(
+                T *ptr,
+                PatternType pattern,
+                size_type size,
+                const vector<Event> *events = nullptr,
+                Event *event = nullptr) const {
+            cl_event tmp;
+            cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+                    object_, static_cast<void *>(ptr), static_cast<void *>(&pattern),
+                    sizeof(PatternType), size,
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != nullptr) ? &tmp : nullptr), __ENQUEUE_FILL_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+
+        /**
+        * Enqueues a command that fills a region of a coarse-grained SVM buffer with a specified pattern.
+        * This variant takes a cl::pointer instance.
+        */
+        template<typename T, class D, typename PatternType>
+        cl_int enqueueMemFillSVM(
+                cl::pointer<T, D> &ptr,
+                PatternType pattern,
+                size_type size,
+                const vector<Event> *events = nullptr,
+                Event *event = nullptr) const {
+            cl_event tmp;
+            cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+                    object_, static_cast<void *>(ptr.get()), static_cast<void *>(&pattern),
+                    sizeof(PatternType), size,
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != nullptr) ? &tmp : nullptr), __ENQUEUE_FILL_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+
+        /**
+        * Enqueues a command that will allow the host to fill a region of a coarse-grained SVM buffer with a specified pattern.
+        * This variant takes a cl::vector instance.
+        */
+        template<typename T, class Alloc, typename PatternType>
+        cl_int enqueueMemFillSVM(
+                cl::vector<T, Alloc> &container,
+                PatternType pattern,
+                const vector<Event> *events = nullptr,
+                Event* event = nullptr) const
+        {
+            cl_event tmp;
+            cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+                    object_, static_cast<void *>(container.data()), static_cast<void *>(&pattern),
+                    sizeof(PatternType), container.size() * sizeof(T),
+                    (events != nullptr) ? (cl_uint) events->size() : 0,
+                    (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                    (event != nullptr) ? &tmp : NULL), __ENQUEUE_FILL_SVM_ERR);
+
+            if (event != nullptr && err == CL_SUCCESS)
+                *event = tmp;
+
+            return err;
+        }
+          /**
      * Enqueues a command that will allow the host to update a region of a coarse-grained SVM buffer.
      * This variant takes a raw SVM pointer.
      */
@@ -8130,7 +8183,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_MAP_BUFFER_ERR);
+            __ENQUEUE_MAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8158,7 +8211,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_MAP_BUFFER_ERR);
+            __ENQUEUE_MAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8184,7 +8237,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_MAP_BUFFER_ERR);
+            __ENQUEUE_MAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8233,7 +8286,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+            __ENQUEUE_UNMAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8258,7 +8311,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+            __ENQUEUE_UNMAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8283,7 +8336,7 @@ public:
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+            __ENQUEUE_UNMAP_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8305,8 +8358,8 @@ public:
      * have completed.
      */
     cl_int enqueueMarkerWithWaitList(
-        const vector<Event> *events = nullptr,
-        Event *event = nullptr) const
+        const vector<Event> *events = 0,
+        Event *event = 0) const
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
@@ -8335,8 +8388,8 @@ public:
      * before this command to command_queue, have completed.
      */
     cl_int enqueueBarrierWithWaitList(
-        const vector<Event> *events = nullptr,
-        Event *event = nullptr) const
+        const vector<Event> *events = 0,
+        Event *event = 0) const
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
@@ -8568,12 +8621,21 @@ public:
         const vector<Event>* events = nullptr,
         Event* event = nullptr) const
     {
+        size_type elements = 0;
+        if (mem_objects != nullptr) {
+            elements = mem_objects->size();
+        }
+        vector<cl_mem> mems(elements);
+        for (unsigned int i = 0; i < elements; i++) {
+            mems[i] = ((*mem_objects)[i])();
+        }
+        
         cl_event tmp;
         cl_int err = detail::errHandler(
             ::clEnqueueNativeKernel(
                 object_, userFptr, args.first, args.second,
                 (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
-                (mem_objects->size() > 0 ) ? reinterpret_cast<const cl_mem *>(mem_objects->data()) : nullptr,
+                mems.data(),
                 (mem_locs != nullptr && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : nullptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -8762,66 +8824,6 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
         return detail::errHandler(::clFinish(object_), __FINISH_ERR);
     }
 
-#ifdef cl_khr_external_memory
-    cl_int enqueueAcquireExternalMemObjects(
-        const vector<Memory>& mem_objects,
-        const vector<Event>* events_wait = nullptr,
-        Event *event = nullptr)
-    {
-        cl_int err = CL_INVALID_OPERATION;
-        cl_event tmp;
-
-        std::call_once(ext_memory_initialized_, initMemoryExtension, this->getInfo<CL_QUEUE_DEVICE>());
-
-        if (pfn_clEnqueueAcquireExternalMemObjectsKHR)
-        {
-            err = pfn_clEnqueueAcquireExternalMemObjectsKHR(
-                object_,
-                static_cast<cl_uint>(mem_objects.size()),
-                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
-                (events_wait != nullptr) ? static_cast<cl_uint>(events_wait->size()) : 0,
-                (events_wait != nullptr && events_wait->size() > 0) ? reinterpret_cast<const cl_event*>(events_wait->data()) : nullptr,
-                &tmp);
-        }
-
-        detail::errHandler(err, __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR);
-
-        if (event != nullptr && err == CL_SUCCESS)
-            *event = tmp;
-
-        return err;
-    }
-
-    cl_int enqueueReleaseExternalMemObjects(
-        const vector<Memory>& mem_objects,
-        const vector<Event>* events_wait = nullptr,
-        Event *event = nullptr)
-    {
-        cl_int err = CL_INVALID_OPERATION;
-        cl_event tmp;
-
-        std::call_once(ext_memory_initialized_, initMemoryExtension, this->getInfo<CL_QUEUE_DEVICE>());
-
-        if (pfn_clEnqueueReleaseExternalMemObjectsKHR)
-        {
-            err = pfn_clEnqueueReleaseExternalMemObjectsKHR(
-                object_,
-                static_cast<cl_uint>(mem_objects.size()),
-                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
-                (events_wait != nullptr) ? static_cast<cl_uint>(events_wait->size()) : 0,
-                (events_wait != nullptr && events_wait->size() > 0) ? reinterpret_cast<const cl_event*>(events_wait->data()) : nullptr,
-                &tmp);
-        }
-
-        detail::errHandler(err, __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR);
-
-        if (event != nullptr && err == CL_SUCCESS)
-            *event = tmp;
-
-        return err;
-    }
-#endif // cl_khr_external_memory && CL_HPP_TARGET_OPENCL_VERSION >= 300
-
 #ifdef cl_khr_semaphore
     cl_int enqueueWaitSemaphores(
         const vector<Semaphore> &sema_objects,
@@ -8836,10 +8838,6 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
         Event* event = nullptr);
 #endif // cl_khr_semaphore
 }; // CommandQueue
-
-#ifdef cl_khr_external_memory
-CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag CommandQueue::ext_memory_initialized_;
-#endif
 
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag CommandQueue::default_initialized_;
 CL_HPP_DEFINE_STATIC_MEMBER_ CommandQueue CommandQueue::default_;
@@ -9400,11 +9398,11 @@ inline cl_int enqueueUnmapSVM(
     cl_int error;
     CommandQueue queue = CommandQueue::getDefault(&error);
     if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        return detail::errHandler(error, __ENQUEUE_UNMAP_SVM_ERR);
     }
 
     return detail::errHandler(queue.enqueueUnmapSVM(ptr, events, event), 
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        __ENQUEUE_UNMAP_SVM_ERR);
 
 }
 
@@ -9422,11 +9420,11 @@ inline cl_int enqueueUnmapSVM(
     cl_int error;
     CommandQueue queue = CommandQueue::getDefault(&error);
     if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        return detail::errHandler(error, __ENQUEUE_UNMAP_SVM_ERR);
     }
 
     return detail::errHandler(queue.enqueueUnmapSVM(ptr, events, event),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        __ENQUEUE_UNMAP_SVM_ERR);
 }
 
 /**
@@ -9443,11 +9441,11 @@ inline cl_int enqueueUnmapSVM(
     cl_int error;
     CommandQueue queue = CommandQueue::getDefault(&error);
     if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        return detail::errHandler(error, __ENQUEUE_UNMAP_SVM_ERR);
     }
 
     return detail::errHandler(queue.enqueueUnmapSVM(container, events, event),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+        __ENQUEUE_UNMAP_SVM_ERR);
 }
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
@@ -11213,7 +11211,11 @@ public:
 #undef __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR  
 #undef __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR  
 #undef __ENQUEUE_MAP_BUFFER_ERR            
-#undef __ENQUEUE_MAP_IMAGE_ERR             
+#undef __ENQUEUE_MAP_IMAGE_ERR
+#undef __ENQUEUE_MAP_SVM_ERR
+#undef __ENQUEUE_FILL_SVM_ERR
+#undef __ENQUEUE_COPY_SVM_ERR
+#undef __ENQUEUE_UNMAP_SVM_ERR             
 #undef __ENQUEUE_UNMAP_MEM_OBJECT_ERR      
 #undef __ENQUEUE_NDRANGE_KERNEL_ERR        
 #undef __ENQUEUE_NATIVE_KERNEL             
@@ -11228,9 +11230,8 @@ public:
 #undef __FLUSH_ERR                         
 #undef __FINISH_ERR                        
 #undef __VECTOR_CAPACITY_ERR               
-#undef __CREATE_SUB_DEVICES_ERR
-#undef __ENQUEUE_ACQUIRE_EXTERNAL_MEMORY_ERR
-#undef __ENQUEUE_RELEASE_EXTERNAL_MEMORY_ERR
+#undef __CREATE_SUB_DEVICES_ERR            
+#undef __CREATE_SUB_DEVICES_ERR            
 #undef __ENQUEUE_MARKER_ERR                
 #undef __ENQUEUE_WAIT_FOR_EVENTS_ERR       
 #undef __ENQUEUE_BARRIER_ERR               
@@ -11255,7 +11256,6 @@ public:
 #endif //CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 
 // Extensions
-#undef CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_
 


### PR DESCRIPTION
1. SVMAllocator::allocate automatically maps the newly allocated SVM buffer. This is redundant for output buffers.I added a new argument to the method – bool map = true – to control whether the method should map the buffer.

2. opencl.hpp doesn't include wrapper methods for clEnqueueSVMMemFill and clEnqueueSVMMemcpy , so I added them.