### PR TITLE
Use v.begin() for vectors instead of ADL begin(v)

### DIFF
--- a/examples/src/headerexample.cpp
+++ b/examples/src/headerexample.cpp
@@ -115,7 +115,7 @@ int main(void)
     // Traditional cl_mem allocations
 
     std::vector<int> output(numElements, 0xdeadbeef);
-    cl::Buffer outputBuffer(begin(output), end(output), false);
+    cl::Buffer outputBuffer(output.begin(), output.end(), false);
     cl::Pipe aPipe(sizeof(cl_int), numElements / 2);
 
     // Default command queue, also passed in as a parameter
@@ -152,7 +152,7 @@ int main(void)
         error
         );
 
-    cl::copy(outputBuffer, begin(output), end(output));
+    cl::copy(outputBuffer, output.begin(), output.end());
 
     cl::Device d = cl::Device::getDefault();
 

--- a/examples/src/trivial.cpp
+++ b/examples/src/trivial.cpp
@@ -167,7 +167,7 @@ int main(void)
 
     // Traditional cl_mem allocations
     std::vector<int> output(numElements, 0xdeadbeef);
-    cl::Buffer outputBuffer(begin(output), end(output), false);
+    cl::Buffer outputBuffer(output.begin(), output.end(), false);
 
     std::vector<int, cl::SVMAllocator<int, cl::SVMTraitCoarse<>>> output2(numElements / 2, 0xdeadbeef);
     cl::Pipe aPipe(sizeof(cl_int), numElements / 2);
@@ -222,7 +222,7 @@ int main(void)
         );
 
     // Copy the cl_mem output back to the vector
-    cl::copy(outputBuffer, begin(output), end(output));
+    cl::copy(outputBuffer, output.begin(), output.end());
     // Grab the SVM output vector using a map
     cl::mapSVM(output2);
 

--- a/examples/src/trivialSizeTCompat.cpp
+++ b/examples/src/trivialSizeTCompat.cpp
@@ -75,9 +75,9 @@ int main(void)
     std::vector<int> inputA(numElements, 1);
     std::vector<int> inputB(numElements, 2);
     std::vector<int> output(numElements, 0xdeadbeef);
-    cl::Buffer inputABuffer(begin(inputA), end(inputA), true);
-    cl::Buffer inputBBuffer(begin(inputB), end(inputB), true);
-    cl::Buffer outputBuffer(begin(output), end(output), false);
+    cl::Buffer inputABuffer(inputA.begin(), inputA.end(), true);
+    cl::Buffer inputBBuffer(inputB.begin(), inputB.end(), true);
+    cl::Buffer outputBuffer(output.begin(), output.end(), false);
     cl::Pipe aPipe(sizeof(cl_int), numElements / 2);
     // Unfortunately, there is no way to check for a default or know if a kernel needs one
     // so the user has to create one
@@ -112,7 +112,7 @@ int main(void)
     cl::size_t<3> WGSizeResult = vectorAddKernel.getKernel().getWorkGroupInfo<CL_KERNEL_COMPILE_WORK_GROUP_SIZE>(cl::Device::getDefault());
     std::cout << "Size_t return: " << WGSizeResult[0] << ", " << WGSizeResult[1] << ", " << WGSizeResult[2] << "\n";
 
-    cl::copy(outputBuffer, begin(output), end(output));
+    cl::copy(outputBuffer, output.begin(), output.end());
 
     cl::Device d = cl::Device::getDefault();
     std::cout << "Max pipe args: " << d.getInfo<CL_DEVICE_MAX_PIPE_ARGS>() << "\n";

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -336,7 +336,7 @@
         // Traditional cl_mem allocations
 
         std::vector<int> output(numElements, 0xdeadbeef);
-        cl::Buffer outputBuffer(begin(output), end(output), false);
+        cl::Buffer outputBuffer(output.begin(), output.end(), false);
         cl::Pipe aPipe(sizeof(cl_int), numElements / 2);
 
         // Default command queue, also passed in as a parameter
@@ -373,7 +373,7 @@
             error
             );
 
-        cl::copy(outputBuffer, begin(output), end(output));
+        cl::copy(outputBuffer, output.begin(), output.end());
 
         cl::Device d = cl::Device::getDefault();
 
@@ -1205,7 +1205,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, string* param, long)
             return err;
         }
         if (param) {
-            param->assign(begin(value), prev(end(value)));
+            param->assign(value.begin(), value.end() - 1);
         }
     }
     else if (param) {
@@ -3363,7 +3363,7 @@ public:
                 return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
             }
 
-            formats->assign(begin(value), end(value));
+            formats->assign(value.begin(), value.end());
         }
         else {
             // If no values are being returned, ensure an empty vector comes back


### PR DESCRIPTION
No functional change (since `begin(x)` on a `std::vector` will always find `std::begin` which dispatches back to `x.begin()` anyway). But member name lookup is a lot cheaper, more idiomatic, and also avoids the arcane problem reported in #197.

Also use `v.end() - 1` instead of `prev(end(v))`.

Fixes #197.