### PR TITLE
fix preprocessor guards for getContextPlatformVersion

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -2086,7 +2086,7 @@ struct ReferenceHandler<cl_mutable_command_khr>
 #endif // cl_khr_command_buffer
 
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
+#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
 // Extracts version number with major in the upper 16 bits, minor in the lower 16
 static cl_uint getVersion(const vector<char> &versionInfo)
 {
@@ -2136,7 +2136,7 @@ static cl_uint getContextPlatformVersion(cl_context context)
     clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
     return getDevicePlatformVersion(devices[0]);
 }
-#endif // CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
 
 template <typename T>
 class Wrapper


### PR DESCRIPTION
fixes #108 

This change corrects the preprocessor guards around detail functions to get the OpenCL version from a platform, device, or context.

* The preprocessor guard for `CL_HPP_TARGET_OPENCL_VERSION` needs to be the **smallest** value that callers of these functions test for.  This is correctly `120` for current usages of these functions.
* The preprocessor guard for `CL_HPP_MINIMUM_OPENCL_VERSION` needs to be the **largest** value that callers of these functions test for.  This needs to be `200`, for example for command queue properties.

Debatably the preprocessor guards around these functions should be removed completely, but at least this way things won't be broken while we figure out if this is the right thing to do or not.