### PR TITLE
fix the last few warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,7 +121,7 @@ jobs:
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -140,7 +140,7 @@ jobs:
         $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -287,7 +287,7 @@ jobs:
       shell: bash
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
-        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -306,7 +306,7 @@ jobs:
         echo -e "include(\"$GITHUB_WORKSPACE/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake\")\ninclude(\"$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/install/share/cmake/OpenCLICDLoader/OpenCLICDLoaderTargets.cmake\")\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/../OpenCLHeadersCpp/OpenCLHeadersCppTargets.cmake\")" > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
         $CMAKE_EXE
         -G "${{matrix.GEN}}"
-        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,16 +81,13 @@ jobs:
 
     - name: Configure
       shell: bash
-      # no -Werror during configuration because:
-      # warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
-      # warning: unused parameter [-Wunused-parameter]
       run: 
         $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D BUILD_TESTING=ON
         -D BUILD_EXAMPLES=ON
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -124,7 +121,7 @@ jobs:
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -143,7 +140,7 @@ jobs:
         $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -251,14 +248,11 @@ jobs:
 
     - name: Configure
       shell: bash
-      # no -Werror during configuration because:
-      # warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
-      # warning: unused parameter [-Wunused-parameter]
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D BUILD_TESTING=ON
         -D BUILD_EXAMPLES=ON
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -293,7 +287,7 @@ jobs:
       shell: bash
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}
@@ -312,7 +306,7 @@ jobs:
         echo -e "include(\"$GITHUB_WORKSPACE/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake\")\ninclude(\"$GITHUB_WORKSPACE/external/OpenCL-ICD-Loader/install/share/cmake/OpenCLICDLoader/OpenCLICDLoaderTargets.cmake\")\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/../OpenCLHeadersCpp/OpenCLHeadersCppTargets.cmake\")" > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
         $CMAKE_EXE
         -G "${{matrix.GEN}}"
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -m${{matrix.BIN}}"
         -D CMAKE_CXX_COMPILER=g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,14 +83,11 @@ jobs:
         --parallel `sysctl -n hw.logicalcpu`
 
     - name: Configure CMake
-      # no -Werror during configuration because:
-      # warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
-      # warning: unused parameter [-Wunused-parameter]
       shell: bash
       run: cmake
         -G "${{matrix.GEN}}"
         -D BUILD_TESTING=ON
-        -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Wno-format -m64"
+        -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic -Wno-format -m64"
         -D CMAKE_CXX_COMPILER=/usr/local/bin/g++-${{matrix.VER}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD}}
         -D CMAKE_CXX_EXTENSIONS=${{matrix.EXT}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,22 +97,16 @@ jobs:
     - name: Configure (MSBuild)
       if: matrix.GEN == 'Visual Studio 17 2022'
       shell: cmd
-      # no /WX during configuration because:
-      # warning C4459: declaration of 'platform' hides global declaration
-      # warning C4100: 'input_headers': unreferenced formal parameter
       run: |
-        set C_FLAGS="/W4"
+        set C_FLAGS="/W4 /WX"
         if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
         %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D BUILD_TESTING=ON -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%\external\OpenCL-Headers\install;%GITHUB_WORKSPACE%\external\OpenCL-ICD-Loader\install" -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build
 
     - name: Configure (Ninja Multi-Config)
       if: matrix.GEN == 'Ninja Multi-Config'
       shell: cmd
-      # no /WX during configuration because:
-      # warning C4459: declaration of 'platform' hides global declaration
-      # warning C4100: 'input_headers': unreferenced formal parameter
       run: |
-        set C_FLAGS="/W4"
+        set C_FLAGS="/W4 /WX"
         if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
         if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
         if /I "${{matrix.VER}}"=="v142" (set VER=14.2)

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -2095,7 +2095,8 @@ struct ReferenceHandler<cl_mutable_command_khr>
 #endif // cl_khr_command_buffer
 
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
+#if (CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120) || \
+    (CL_HPP_TARGET_OPENCL_VERSION >= 200 && CL_HPP_MINIMUM_OPENCL_VERSION < 200)
 // Extracts version number with major in the upper 16 bits, minor in the lower 16
 static cl_uint getVersion(const vector<char> &versionInfo)
 {
@@ -2145,7 +2146,7 @@ static cl_uint getContextPlatformVersion(cl_context context)
     clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
     return getDevicePlatformVersion(devices[0]);
 }
-#endif // CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
+#endif // CL_HPP_TARGET_OPENCL_VERSION && CL_HPP_MINIMUM_OPENCL_VERSION
 
 template <typename T>
 class Wrapper
@@ -2254,18 +2255,16 @@ protected:
     static bool isReferenceCountable(cl_device_id device)
     {
         bool retVal = false;
-#if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#if CL_HPP_MINIMUM_OPENCL_VERSION < 120
+#if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
         if (device != nullptr) {
             int version = getDevicePlatformVersion(device);
             if(version > ((1 << 16) + 1)) {
                 retVal = true;
             }
         }
-#else // CL_HPP_MINIMUM_OPENCL_VERSION < 120
+#elif CL_HPP_TARGET_OPENCL_VERSION >= 120
         retVal = true;
-#endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
-#endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
+#endif // CL_HPP_TARGET_OPENCL_VERSION
         (void)device;
         return retVal;
     }

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -3204,10 +3204,10 @@ private:
 #if defined(cl_ext_image_requirements_info)
     struct ImageRequirementsInfo {
 
-        ImageRequirementsInfo(cl_mem_flags f, const cl_mem_properties* properties, const ImageFormat* format, const cl_image_desc* desc)
+        ImageRequirementsInfo(cl_mem_flags f, const cl_mem_properties* p, const ImageFormat* format, const cl_image_desc* desc)
         {
             flags = f;
-            properties = properties;
+            properties = p;
             image_format = format;
             image_desc = desc;
         }

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3710,7 +3710,7 @@ static cl_int clCreateSubDevicesEXT_testDevice_createSubDevices(
   }
 }
 
-void testDevice_createSubDevices() {
+void testDevice_createSubDevices(void) {
 #ifndef CL_HPP_ENABLE_EXCEPTIONS
   const cl_device_partition_property_ext properties =
       CL_DEVICE_PARTITION_EQUALLY_EXT;
@@ -4552,7 +4552,7 @@ static cl_int clGetGLObjectInfo_testgetObjectInfo(cl_mem memobj,
     return CL_SUCCESS;
 }
 
-void testgetObjectInfo() {
+void testgetObjectInfo(void) {
     cl_mem_flags flags = 0;
     cl_int err = 0;
     cl_GLuint bufobj = 0;
@@ -4581,7 +4581,7 @@ static cl_int clGetHostTimer_testgetHostTimer(cl_device_id device,
     return 0;
 }
 
-void testgetHostTimer() {
+void testgetHostTimer(void) {
     cl_ulong retVal = 0;
     cl_int *error = nullptr;
 
@@ -4590,6 +4590,6 @@ void testgetHostTimer() {
     TEST_ASSERT_EQUAL(retVal, 1);
 }
 #else
-void testgetHostTimer() {}
+void testgetHostTimer(void) {}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 210
 } // extern "C"

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3258,7 +3258,7 @@ static cl_int clGetDeviceInfo_uuid_pci_bus_info(
                 (param_name == CL_DEVICE_UUID_KHR) ? 1 :
                 (param_name == CL_DRIVER_UUID_KHR) ? 2 :
                 0;
-            for (int i = 0; i < CL_UUID_SIZE_KHR; i++) {
+            for (cl_uchar i = 0; i < CL_UUID_SIZE_KHR; i++) {
                 pUUID[i] = i + start;
             }
         }
@@ -3282,7 +3282,7 @@ static cl_int clGetDeviceInfo_uuid_pci_bus_info(
         if (param_value_size == CL_LUID_SIZE_KHR && param_value) {
             cl_uchar* pLUID = static_cast<cl_uchar*>(param_value);
             cl_uchar start = 3;
-            for (int i = 0; i < CL_LUID_SIZE_KHR; i++) {
+            for (cl_uchar i = 0; i < CL_LUID_SIZE_KHR; i++) {
                 pLUID[i] = i + start;
             }
         }

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3741,7 +3741,7 @@ void testMoveAssignSemaphoreNonNull(void);
 void testMoveAssignSemaphoreNull(void);
 void testMoveConstructSemaphoreNonNull(void);
 void testMoveConstructSemaphoreNull(void);
-MAKE_MOVE_TESTS(Semaphore, make_semaphore_khr, clReleaseSemaphoreKHR, semaphorePool);
+MAKE_MOVE_TESTS(Semaphore, make_semaphore_khr, clReleaseSemaphoreKHR, semaphorePool)
 #else
 void testMoveAssignSemaphoreNonNull(void) {}
 void testMoveAssignSemaphoreNull(void) {}


### PR DESCRIPTION
This PR fixes the last few warnings:

1. Fixes an incorrect assignment in the ImageRequirementsInfo constructor.  Note, this is a real bug, and probably indicates a testing gap.
3. Fixes a pedantic warning about an extraneous semicolon in the unit tests.
4. Fixes a pedantic warning about using the logical not operator with an integer literal in the unit tests.

With these warnings fixed it's now OK to enable warnings as errors in CI if we choose to do so.  I've done that for now, also as a way to ensure I fixed all warnings, though I'm OK backing these changes out if we decide we don't want to do this for whatever reason.