### PR TITLE
add tests for all valid combinations of min and target version

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,3 +160,26 @@ foreach(VERSION 120 200 210 220 300)
     add_test(NAME ${TEST_EXE} COMMAND ${TEST_EXE})
   endforeach(OPTION)
 endforeach(VERSION)
+
+if(NOT TARGET OpenCL::openCL)
+  find_package(OpenCLICDLoader)
+endif()
+if(TARGET OpenCL::OpenCL)
+  # TODO enable testing for OpenCL 1.0 and 1.1
+  foreach(MINVERSION 120 200 210 220 300)
+    foreach(TARGETVERSION 120 200 210 220 300)
+      if(NOT (${MINVERSION} GREATER ${TARGETVERSION}))
+        set(TEST_EXE test_openclhpp_version_min_${MINVERSION}_target_${TARGETVERSION})
+        add_executable(${TEST_EXE} test_versions.cpp)
+        target_compile_definitions(${TEST_EXE} PUBLIC
+          CL_HPP_MINIMUM_OPENCL_VERSION=${MINVERSION}
+          CL_HPP_TARGET_OPENCL_VERSION=${TARGETVERSION})
+        target_link_libraries(${TEST_EXE} PRIVATE
+          OpenCL::HeadersCpp
+          OpenCL::Headers
+          OpenCL::OpenCL)
+        add_test(NAME ${TEST_EXE} COMMAND ${TEST_EXE})
+      endif()
+    endforeach()
+  endforeach()
+endif()

--- a/tests/test_versions.cpp
+++ b/tests/test_versions.cpp
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2023 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <CL/opencl.hpp>
+#include <iostream>
+
+int main(void)
+{
+    std::cout << "opencl.hpp version permutation test PASSED.\n";
+    return 0;
+}


### PR DESCRIPTION
This PR adds very simple tests to ensure there are no compile errors when compiling the C++ headers for all combinations of the minimum and target OpenCL versions.  Some of these tests will fail until #245 is merged.