### PR TITLE
use the new semaphore specific device handle list enum

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1535,13 +1535,19 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
 #define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(F) \
     F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr)
 
+// This allows building with older headers.
+// It can be removed when updated headers are widespread.
+#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
+#endif
+
 #define CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(F) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_CONTEXT_KHR, cl::Context) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_REFERENCE_COUNT_KHR, cl_uint) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_PROPERTIES_KHR, cl::vector<cl_semaphore_properties_khr>) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_TYPE_KHR, cl_semaphore_type_khr) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_PAYLOAD_KHR, cl_semaphore_payload_khr) \
-    F(cl_semaphore_info_khr, CL_DEVICE_HANDLE_LIST_KHR, cl::vector<cl::Device>) \
+    F(cl_semaphore_info_khr, CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, cl::vector<cl::Device>) \
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_TYPES_KHR,  cl::vector<cl_semaphore_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_TYPES_KHR,      cl::vector<cl_semaphore_type_khr>) \
 

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1535,19 +1535,13 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
 #define CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(F) \
     F(cl_device_info, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR, cl_version_khr)
 
-// This allows building with older headers.
-// It can be removed when updated headers are widespread.
-#if !defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
-#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR CL_DEVICE_HANDLE_LIST_KHR
-#endif
-
+// Note: the query for CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR is handled specially!
 #define CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(F) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_CONTEXT_KHR, cl::Context) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_REFERENCE_COUNT_KHR, cl_uint) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_PROPERTIES_KHR, cl::vector<cl_semaphore_properties_khr>) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_TYPE_KHR, cl_semaphore_type_khr) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_PAYLOAD_KHR, cl_semaphore_payload_khr) \
-    F(cl_semaphore_info_khr, CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, cl::vector<cl::Device>) \
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_TYPES_KHR,  cl::vector<cl_semaphore_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_TYPES_KHR,      cl::vector<cl_semaphore_type_khr>) \
 
@@ -1555,7 +1549,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>) \
     F(cl_platform_info, CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl::ExternalMemoryType>)
 
-#define CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_EXT(F) \
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_(F) \
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR,  cl::vector<cl_external_semaphore_handle_type_khr>) \
     F(cl_platform_info, CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR,  cl::vector<cl_external_semaphore_handle_type_khr>) \
     F(cl_device_info, CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR,      cl::vector<cl_external_semaphore_handle_type_khr>) \
@@ -1688,14 +1682,17 @@ CL_HPP_PARAM_NAME_CL_KHR_EXTENDED_VERSIONING_KHRONLY_(CL_HPP_DECLARE_PARAM_TRAIT
 
 #if defined(cl_khr_semaphore)
 CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_(CL_HPP_DECLARE_PARAM_TRAITS_)
-#endif // cl_khr_semaphore
+#if defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_semaphore_info_khr, CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, cl::vector<cl::Device>)
+#endif // defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
+#endif // defined(cl_khr_semaphore)
 
 #ifdef cl_khr_external_memory
 CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_khr_external_memory
 
 #if defined(cl_khr_external_semaphore)
-CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_khr_external_semaphore
 
 #if defined(cl_khr_external_semaphore_dx_fence)

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -4010,7 +4010,7 @@ static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetDevices(
     static const cl_device_id test_devices[] =
         {make_device_id(0), make_device_id(1)};
     TEST_ASSERT_EQUAL_PTR(semaphorePool[0](), sema_object);
-    TEST_ASSERT_EQUAL_HEX(CL_DEVICE_HANDLE_LIST_KHR, param_name);
+    TEST_ASSERT_EQUAL_HEX(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, param_name);
     TEST_ASSERT(param_value == nullptr || param_value_size >= sizeof(test_devices));
     if (param_value_size_ret != nullptr)
         *param_value_size_ret = sizeof(test_devices);
@@ -4035,7 +4035,7 @@ void testSemaphoreGetInfoDevicesList(void)
 
     cl_int err = CL_INVALID_OPERATION;
 
-    VECTOR_CLASS<cl::Device> ret = semaphorePool[0].getInfo<CL_DEVICE_HANDLE_LIST_KHR>(&err);
+    VECTOR_CLASS<cl::Device> ret = semaphorePool[0].getInfo<CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR>(&err);
 
     TEST_ASSERT_EQUAL(CL_SUCCESS, err);
     TEST_ASSERT_EQUAL(2, ret.size());

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -3998,6 +3998,7 @@ void testSemaphoreGetInfoPayload(void)
     TEST_ASSERT_EQUAL(1, ret);
 }
 
+#if defined(CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR)
 static cl_int clGetSemaphoreInfoKHR_testSemaphoreGetDevices(
     cl_semaphore_khr sema_object,
     cl_semaphore_info_khr param_name,
@@ -4042,6 +4043,9 @@ void testSemaphoreGetInfoDevicesList(void)
     TEST_ASSERT_EQUAL(make_device_id(0), ret[0]());
     TEST_ASSERT_EQUAL(make_device_id(1), ret[1]());
 }
+#else
+void testSemaphoreGetInfoDevicesList(void) {}
+#endif
 
 void testSemaphoreRetain(void)
 {


### PR DESCRIPTION
Updates the C++ bindings to use the new semaphore-specific device handle list enum rather than the older overloaded enum.

Includes a preprocessor check so these changes will work with both older and newer headers.  When newer headers become widespread we can remove this check - this could be part of this PR or in a subsequent PR.

For reference, the PR to update the headers with the new enums is: https://github.com/KhronosGroup/OpenCL-Headers/pull/240