### PR TITLE
Added wrapper constructors for clCreateImageWithProperties

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -4828,6 +4828,49 @@ public:
     //! \brief Default constructor - initializes to nullptr.
     Image1D() { }
 
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image1D(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type width,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D;
+        desc.image_width = width;
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, host_ptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
@@ -4888,6 +4931,49 @@ public:
 
     Image1DBuffer() { }
 
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1DBuffer with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param buffer Refer to a valid buffer or image memory object.
+     */
+    Image1DBuffer(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type width,
+        const Buffer &buffer,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
+        desc.image_width = width;
+        desc.buffer = buffer();
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, nullptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, nullptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
@@ -4947,6 +5033,53 @@ public:
     }
 
     Image1DArray() { }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1DArray with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image1DArray(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type arraySize,
+        size_type width,
+        size_type rowPitch,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
+        desc.image_width = width;
+        desc.image_array_size = arraySize;
+        desc.image_row_pitch = rowPitch;
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, host_ptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
   
     /*! \brief Constructor from cl_mem - takes ownership.
      *
@@ -5150,6 +5283,103 @@ public:
     }
 #endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image2D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image2D(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type width,
+        size_type height,
+        size_type row_pitch = 0,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_row_pitch = row_pitch;
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, host_ptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+
+    /*! \brief Constructs a Image2D with specified properties.
+     *
+     *  Requires OpenCL 2.0 or newer or OpenCL 1.2 and the
+     *  cl_khr_image2d_from_buffer extension.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param buffer Refer to a valid buffer or image memory object.
+     */
+    Image2D(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        const Buffer &buffer,
+        size_type width,
+        size_type height,
+        size_type row_pitch = 0,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_row_pitch = row_pitch;
+        desc.buffer = buffer();
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, nullptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, nullptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+
     //! \brief Default constructor - initializes to nullptr.
     Image2D() { }
 
@@ -5172,10 +5402,6 @@ public:
         Image::operator=(rhs);
         return *this;
     }
-
-
-
-
 };
 
 
@@ -5292,6 +5518,57 @@ public:
         }
     }
 
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image2DArray with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image2DArray(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type arraySize,
+        size_type width,
+        size_type height,
+        size_type rowPitch,
+        size_type slicePitch,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_array_size = arraySize;
+        desc.image_row_pitch = rowPitch;
+        desc.image_slice_pitch = slicePitch;
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, host_ptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+
     Image2DArray() { }
     
     /*! \brief Constructor from cl_mem - takes ownership.
@@ -5391,6 +5668,57 @@ public:
         }
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
     }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image3D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image3D(
+        const Context& context,
+        const vector<cl_mem_properties>& properties,
+        cl_mem_flags flags,
+        ImageFormat format,
+        size_type width,
+        size_type height,
+        size_type depth,
+        size_type row_pitch = 0,
+        size_type slice_pitch = 0,
+        void* host_ptr = nullptr,
+        cl_int* err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE3D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_depth = depth;
+        desc.image_row_pitch = row_pitch;
+        desc.image_slice_pitch = slice_pitch;
+
+        if (properties.empty()) {
+            object_ = ::clCreateImageWithProperties(context(), nullptr, flags, &format,
+                                                     &desc, host_ptr, &error);
+        }
+        else {
+            object_ = ::clCreateImageWithProperties(
+                context(), properties.data(), flags, &format,
+                        &desc, host_ptr, &error);
+        }
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     //! \brief Default constructor - initializes to nullptr.
     Image3D() : Image() { }

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -4989,9 +4989,6 @@ public:
         Image::operator=(rhs);
         return *this;
     }
-
-
-
 };
 
 /*! \class Image1DArray
@@ -5052,7 +5049,7 @@ public:
         ImageFormat format,
         size_type arraySize,
         size_type width,
-        size_type rowPitch,
+        size_type rowPitch=0,
         void* host_ptr = nullptr,
         cl_int* err = nullptr)
     {
@@ -5537,8 +5534,8 @@ public:
         size_type arraySize,
         size_type width,
         size_type height,
-        size_type rowPitch,
-        size_type slicePitch,
+        size_type rowPitch=0,
+        size_type slicePitch=0,
         void* host_ptr = nullptr,
         cl_int* err = nullptr)
     {

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -5333,9 +5333,6 @@ public:
 
     /*! \brief Constructs a Image2D with specified properties.
      *
-     *  Requires OpenCL 2.0 or newer or OpenCL 1.2 and the
-     *  cl_khr_image2d_from_buffer extension.
-     *
      *  Wraps clCreateImageWithProperties().
      *
      *  \param properties Optional list of properties for the image object and


### PR DESCRIPTION
Added constructors for `Image1D`, `Image1DArray`, `Image1DBuffer`, `Image2D`, `Image2DArray`, `Image3D`. 

I have tested/discussed most of new constructors in real environment, [here](https://github.com/Mobica/OpenCL-SDK/tree/test-clcreateimagewithproperties) is modified `juliavk` sample from @bashbaug [repository](https://github.com/bashbaug/SimpleOpenCLSamples) to test new constructors. 