### PR TITLE
expose header parameters in clCompileProgram

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -6720,7 +6720,7 @@ public:
     }
 
     cl_int compile(
-        const char* options,
+        const string options,
         const vector<Program>& inputHeaders,
         const vector<string>& headerIncludeNames,
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
@@ -6734,7 +6734,7 @@ public:
             object_,
             0,
             nullptr,
-            options,
+            options.c_str(),
             static_cast<cl_uint>(inputHeaders.size()),
             reinterpret_cast<const cl_program*>(inputHeaders.data()),
             reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),
@@ -6744,7 +6744,7 @@ public:
     }
 
     cl_int compile(
-        const char* options,
+        const string options,
         const vector<Device>& deviceList,
         const vector<Program>& inputHeaders = vector<Program>(),
         const vector<string>& headerIncludeNames = vector<string>(),
@@ -6759,7 +6759,7 @@ public:
             object_,
             static_cast<cl_uint>(deviceList.size()),
             reinterpret_cast<const cl_device_id*>(deviceList.data()),
-            options,
+            options.c_str(),
             static_cast<cl_uint>(inputHeaders.size()),
             reinterpret_cast<const cl_program*>(inputHeaders.data()),
             reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -6720,14 +6720,16 @@ public:
     }
 
     cl_int compile(
-        const string options,
+        const string& options,
         const vector<Program>& inputHeaders,
         const vector<string>& headerIncludeNames,
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
+        static_assert(sizeof(cl::Program) == sizeof(cl_program),
+            "Size of cl::Program must be equal to size of cl_program");
         vector<const char*> headerIncludeNamesCStr;
-        for(string name: headerIncludeNames) {
+        for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
         }
         cl_int error = ::clCompileProgram(
@@ -6744,21 +6746,27 @@ public:
     }
 
     cl_int compile(
-        const string options,
+        const string& options,
         const vector<Device>& deviceList,
         const vector<Program>& inputHeaders = vector<Program>(),
         const vector<string>& headerIncludeNames = vector<string>(),
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
+        static_assert(sizeof(cl::Program) == sizeof(cl_program),
+            "Size of cl::Program must be equal to size of cl_program");
         vector<const char*> headerIncludeNamesCStr;
-        for(string name: headerIncludeNames) {
+        for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
+        }
+        vector<const cl_device_id*> deviceIDList;
+        for(const Device& device: deviceList) {
+            deviceIDList.push_back(device());
         }
         cl_int error = ::clCompileProgram(
             object_,
             static_cast<cl_uint>(deviceList.size()),
-            reinterpret_cast<const cl_device_id*>(deviceList.data()),
+            reinterpret_cast<const cl_device_id*>(deviceIDList.data()),
             options.c_str(),
             static_cast<cl_uint>(inputHeaders.size()),
             reinterpret_cast<const cl_program*>(inputHeaders.data()),

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -6703,6 +6703,9 @@ public:
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
     cl_int compile(
         const char* options = nullptr,
+        cl_uint num_input_headers = 0,
+        const cl_program* input_headers = nullptr,
+        const char** header_include_names = nullptr,
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
@@ -6711,9 +6714,9 @@ public:
             0,
             nullptr,
             options,
-            0,
-            nullptr,
-            nullptr,
+            num_input_headers,
+            input_headers,
+            header_include_names,
             notifyFptr,
             data);
         return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -6703,9 +6703,6 @@ public:
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
     cl_int compile(
         const char* options = nullptr,
-        cl_uint num_input_headers = 0,
-        const cl_program* input_headers = nullptr,
-        const char** header_include_names = nullptr,
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
@@ -6714,9 +6711,58 @@ public:
             0,
             nullptr,
             options,
-            num_input_headers,
-            input_headers,
-            header_include_names,
+            0,
+            nullptr,
+            nullptr,
+            notifyFptr,
+            data);
+        return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
+    }
+
+    cl_int compile(
+        const char* options,
+        const vector<Program>& inputHeaders,
+        const vector<string>& headerIncludeNames,
+        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
+        void* data = nullptr) const
+    {
+        vector<const char*> headerIncludeNamesCStr;
+        for(string name: headerIncludeNames) {
+            headerIncludeNamesCStr.push_back(name.c_str());
+        }
+        cl_int error = ::clCompileProgram(
+            object_,
+            0,
+            nullptr,
+            options,
+            static_cast<cl_uint>(inputHeaders.size()),
+            reinterpret_cast<const cl_program*>(inputHeaders.data()),
+            reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),
+            notifyFptr,
+            data);
+        return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
+    }
+
+    cl_int compile(
+        const char* options,
+        const vector<Device>& deviceList,
+        const vector<Program>& inputHeaders = vector<Program>(),
+        const vector<string>& headerIncludeNames = vector<string>(),
+        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
+        void* data = nullptr) const
+    {
+        vector<const char*> headerIncludeNamesCStr;
+        for(string name: headerIncludeNames) {
+            headerIncludeNamesCStr.push_back(name.c_str());
+        }
+        cl_int error = ::clCompileProgram(
+            object_,
+            static_cast<cl_uint>(deviceList.size()),
+            reinterpret_cast<const cl_device_id*>(deviceList.data()),
+            options,
+            static_cast<cl_uint>(inputHeaders.size()),
+            reinterpret_cast<const cl_program*>(inputHeaders.data()),
+            reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),
             notifyFptr,
             data);
         return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -6759,7 +6759,7 @@ public:
         for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
         }
-        vector<const cl_device_id*> deviceIDList;
+        vector<cl_device_id> deviceIDList;
         for(const Device& device: deviceList) {
             deviceIDList.push_back(device());
         }

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -2159,6 +2159,7 @@ static cl_int clGetProgramInfo_forBuildLog(
 {
     (void) num_calls;
 
+    TEST_ASSERT_EQUAL(program, make_program(0));
     TEST_ASSERT_EQUAL(param_name, CL_PROGRAM_DEVICES);
     if (param_value_size) {
         TEST_ASSERT_EQUAL(param_value_size, sizeof(cl_device_id));


### PR DESCRIPTION
I use this to include dynamically generated headers.
Exposing this should offer more flexibility without breaking existing code due to the defaults.