### PR TITLE
CI fix: disable the same warnings that opencl-icd-loader disables

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -295,7 +295,10 @@ jobs:
       UseMultiToolTask: true # Better parallel MSBuild execution
       EnforceProcessCountAcrossBuilds: 'true' # -=-
       MultiProcMaxCount: '3'                  # -=-
-      CFLAGS: /W4 /WX
+      # C4152: nonstandard extension, function/data pointer conversion in expression
+      # C4201: nonstandard extension used: nameless struct/union
+      # C4310: cast truncates constant value
+      CFLAGS: /W4 /WX /wd4152 /wd4201 /wd4310
       CXXFLAGS: /W4 /WX
 
     steps:


### PR DESCRIPTION
This change should fix the CI failures on the main branch.  Basically, it updates the Windows C compiler flags to disable several warnings that are needed to compile the OpenCL ICD loader (and that are also disabled in the OpenCL ICD loader CI).

https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/c2cbdb33605ef9cfa02aa2a77e9cd7306c57e32a/.github/workflows/presubmit.yml#L251