### PR TITLE
Update clUpdateMutableCommandsKHR binding

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -11549,6 +11549,8 @@ public:
     }
 
 #if defined(cl_khr_command_buffer_mutable_dispatch)
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION <                 \
+    CL_MAKE_VERSION(0, 9, 2)
     cl_int updateMutableCommands(const cl_mutable_base_config_khr* mutable_config)
     {
         if (pfn_clUpdateMutableCommandsKHR == nullptr) {
@@ -11558,6 +11560,21 @@ public:
         return detail::errHandler(pfn_clUpdateMutableCommandsKHR(object_, mutable_config),
                         __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
     }
+#else
+    template <int ArrayLength>
+    cl_int updateMutableCommands(std::array<cl_command_buffer_update_type_khr,
+                                            ArrayLength> &config_types,
+                                 std::array<void *, ArrayLength> &configs) {
+        if (pfn_clUpdateMutableCommandsKHR == nullptr) {
+            return detail::errHandler(CL_INVALID_OPERATION,
+                                      __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
+        }
+        return detail::errHandler(
+            pfn_clUpdateMutableCommandsKHR(object_, configs.length(),
+                                           config_types.data().configs.data()),
+            __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
+    }
+#endif /* CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION */
 #endif /* cl_khr_command_buffer_mutable_dispatch */
 
 private:


### PR DESCRIPTION
In OpenCL-Docs PR https://github.com/KhronosGroup/OpenCL-Docs/pull/1045 the API for `cl_khr_command_buffer_mutable_dispatch` API `clUpdateMutableCommandsKHR` changed in a breaking way.

When the headers update OpenCL-Headers PR https://github.com/KhronosGroup/OpenCL-Headers/pull/245 the bindings will break if they are not updated to reflect this change.

Bindings updated in this PR to pass to arrays of templated length to the C++ method. The underlying `.data()` pointers of these parameters can be passed through to the OpenCL API. I don't think any tests for this API currently exist in the repo to be updated.