### PR TITLE
Fix updateMutableCommands template to use std::array::size() and const pointers

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -11876,14 +11876,14 @@ public:
     template <int ArrayLength>
     cl_int updateMutableCommands(std::array<cl_command_buffer_update_type_khr,
                                             ArrayLength> &config_types,
-                                 std::array<void *, ArrayLength> &configs) {
+                                 std::array<const void *, ArrayLength> &configs) {
         if (pfn_clUpdateMutableCommandsKHR == nullptr) {
             return detail::errHandler(CL_INVALID_OPERATION,
                                       __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
         }
         return detail::errHandler(
-            pfn_clUpdateMutableCommandsKHR(object_, configs.length(),
-                                           config_types.data().configs.data()),
+            pfn_clUpdateMutableCommandsKHR(object_, configs.size(),
+                                           config_types.data(), configs.data()),
             __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
     }
 #endif /* CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION */


### PR DESCRIPTION
This pull request fixes this commit https://github.com/KhronosGroup/OpenCL-CLHPP/pull/298:

- Replaced configs.length() with configs.size() to correctly retrieve the array size.
- Changed configs to std::array<const void*, ArrayLength> for better const-correctness.
- Passed config_types.data(), configs.data() directly to pfn_clUpdateMutableCommandsKHR.