### PR TITLE
disable use of stdext::checked_array_iterator for VS2019 and newer

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -10299,15 +10299,15 @@ inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, Itera
     if( error != CL_SUCCESS ) {
         return error;
     }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1920
     std::copy(
-        startIterator, 
-        endIterator, 
+        startIterator,
+        endIterator,
         stdext::checked_array_iterator<DataType*>(
             pointer, length));
 #else
     std::copy(startIterator, endIterator, pointer);
-#endif
+#endif // defined(_MSC_VER) && _MSC_VER < 1920
     Event endEvent;
     error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
     // if exceptions enabled, enqueueUnmapMemObject will throw


### PR DESCRIPTION
Possible fix for https://github.com/KhronosGroup/OpenCL-CLHPP/issues/293.

It seems that the use of `stdext::checked_array_iterator` is not required for VS2019 and newer.  So, add `_MSC_VER` checks to fall back to the generic version for newer versions of Visual Studio.