### PR TITLE
Add support for CL_HPP_OPENCL_API_WRAPPER macro

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -206,6 +206,11 @@
  *
  *   Enable the cl_khr_il_program extension.
  *
+ * - CL_HPP_OPENCL_API_WRAPPER
+ *
+ *   A macro which is used to wrap all OpenCL API symbols. This can be
+ *   used e.g. to load the OpenCL library dynamically with dlopen()/dlsym().
+ *
  *
  * \section example Example
  *
@@ -391,6 +396,12 @@
  */
 #ifndef CL_HPP_
 #define CL_HPP_
+
+#ifdef CL_HPP_OPENCL_API_WRAPPER
+#define CL_(name) CL_HPP_OPENCL_API_WRAPPER(name)
+#else
+#define CL_(name) ::name
+#endif
 
 /* Handle deprecated preprocessor definitions. In each case, we only check for
  * the old name if the new name is not defined, so that user code can define
@@ -703,15 +714,15 @@ namespace cl {
 #define CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(name) \
     using PFN_##name = name##_fn
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name)                               \
-    if (!pfn_##name) {                                                  \
-        pfn_##name = (PFN_##name)clGetExtensionFunctionAddress(#name);  \
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name)                                    \
+    if (!pfn_##name) {                                                       \
+        pfn_##name = (PFN_##name)CL_(clGetExtensionFunctionAddress)(#name);  \
     }
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name)            \
-    if (!pfn_##name) {                                                  \
-        pfn_##name = (PFN_##name)                                       \
-            clGetExtensionFunctionAddressForPlatform(platform, #name);  \
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name)                 \
+    if (!pfn_##name) {                                                       \
+        pfn_##name = (PFN_##name)                                            \
+            CL_(clGetExtensionFunctionAddressForPlatform)(platform, #name);  \
     }
 
 #ifdef cl_khr_external_memory
@@ -1979,7 +1990,7 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_HOST_MEMORY
      */
     static cl_int retain(cl_device_id device)
-    { return ::clRetainDevice(device); }
+    { return CL_(clRetainDevice)(device); }
     /**
      * Retain the device.
      * \param device A valid device created using createSubDevices
@@ -1990,7 +2001,7 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_HOST_MEMORY
      */
     static cl_int release(cl_device_id device)
-    { return ::clReleaseDevice(device); }
+    { return CL_(clReleaseDevice)(device); }
 };
 #else // CL_HPP_TARGET_OPENCL_VERSION >= 120
 /**
@@ -2023,63 +2034,63 @@ template <>
 struct ReferenceHandler<cl_context>
 {
     static cl_int retain(cl_context context)
-    { return ::clRetainContext(context); }
+    { return CL_(clRetainContext)(context); }
     static cl_int release(cl_context context)
-    { return ::clReleaseContext(context); }
+    { return CL_(clReleaseContext)(context); }
 };
 
 template <>
 struct ReferenceHandler<cl_command_queue>
 {
     static cl_int retain(cl_command_queue queue)
-    { return ::clRetainCommandQueue(queue); }
+    { return CL_(clRetainCommandQueue)(queue); }
     static cl_int release(cl_command_queue queue)
-    { return ::clReleaseCommandQueue(queue); }
+    { return CL_(clReleaseCommandQueue)(queue); }
 };
 
 template <>
 struct ReferenceHandler<cl_mem>
 {
     static cl_int retain(cl_mem memory)
-    { return ::clRetainMemObject(memory); }
+    { return CL_(clRetainMemObject)(memory); }
     static cl_int release(cl_mem memory)
-    { return ::clReleaseMemObject(memory); }
+    { return CL_(clReleaseMemObject)(memory); }
 };
 
 template <>
 struct ReferenceHandler<cl_sampler>
 {
     static cl_int retain(cl_sampler sampler)
-    { return ::clRetainSampler(sampler); }
+    { return CL_(clRetainSampler)(sampler); }
     static cl_int release(cl_sampler sampler)
-    { return ::clReleaseSampler(sampler); }
+    { return CL_(clReleaseSampler)(sampler); }
 };
 
 template <>
 struct ReferenceHandler<cl_program>
 {
     static cl_int retain(cl_program program)
-    { return ::clRetainProgram(program); }
+    { return CL_(clRetainProgram)(program); }
     static cl_int release(cl_program program)
-    { return ::clReleaseProgram(program); }
+    { return CL_(clReleaseProgram)(program); }
 };
 
 template <>
 struct ReferenceHandler<cl_kernel>
 {
     static cl_int retain(cl_kernel kernel)
-    { return ::clRetainKernel(kernel); }
+    { return CL_(clRetainKernel)(kernel); }
     static cl_int release(cl_kernel kernel)
-    { return ::clReleaseKernel(kernel); }
+    { return CL_(clReleaseKernel)(kernel); }
 };
 
 template <>
 struct ReferenceHandler<cl_event>
 {
     static cl_int retain(cl_event event)
-    { return ::clRetainEvent(event); }
+    { return CL_(clRetainEvent)(event); }
     static cl_int release(cl_event event)
-    { return ::clReleaseEvent(event); }
+    { return CL_(clReleaseEvent)(event); }
 };
 
 #ifdef cl_khr_semaphore
@@ -2164,17 +2175,17 @@ static cl_uint getVersion(const vector<char> &versionInfo)
 static cl_uint getPlatformVersion(cl_platform_id platform)
 {
     size_type size = 0;
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, nullptr, &size);
+    CL_(clGetPlatformInfo)(platform, CL_PLATFORM_VERSION, 0, nullptr, &size);
 
     vector<char> versionInfo(size);
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
+    CL_(clGetPlatformInfo)(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
     return getVersion(versionInfo);
 }
 
 static cl_uint getDevicePlatformVersion(cl_device_id device)
 {
     cl_platform_id platform;
-    clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr);
+    CL_(clGetDeviceInfo)(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr);
     return getPlatformVersion(platform);
 }
 
@@ -2183,11 +2194,11 @@ static cl_uint getContextPlatformVersion(cl_context context)
     // The platform cannot be queried directly, so we first have to grab a
     // device and obtain its context
     size_type size = 0;
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, 0, nullptr, &size);
+    CL_(clGetContextInfo)(context, CL_CONTEXT_DEVICES, 0, nullptr, &size);
     if (size == 0)
         return 0;
     vector<cl_device_id> devices(size/sizeof(cl_device_id));
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
+    CL_(clGetContextInfo)(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
     return getDevicePlatformVersion(devices[0]);
 }
 #endif // CL_HPP_TARGET_OPENCL_VERSION && CL_HPP_MINIMUM_OPENCL_VERSION
@@ -2562,7 +2573,7 @@ public:
     cl_int getInfo(cl_device_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetDeviceInfo, object_, name, param),
+            detail::getInfo(CL_(clGetDeviceInfo), object_, name, param),
             __GET_DEVICE_INFO_ERR);
     }
 
@@ -2591,7 +2602,7 @@ public:
     {
         cl_ulong retVal = 0;
         cl_int err = 
-            clGetHostTimer(this->get(), &retVal);
+            CL_(clGetHostTimer)(this->get(), &retVal);
         detail::errHandler(
             err,
             __GET_HOST_TIMER_ERR);
@@ -2615,7 +2626,7 @@ public:
     {
         std::pair<cl_ulong, cl_ulong> retVal;
         cl_int err =
-            clGetDeviceAndHostTimer(this->get(), &(retVal.first), &(retVal.second));
+            CL_(clGetDeviceAndHostTimer)(this->get(), &(retVal.first), &(retVal.second));
         detail::errHandler(
             err,
             __GET_DEVICE_AND_HOST_TIMER_ERR);
@@ -2720,7 +2731,7 @@ private:
             // Otherwise set it
             cl_uint n = 0;
 
-            cl_int err = ::clGetPlatformIDs(0, nullptr, &n);
+            cl_int err = CL_(clGetPlatformIDs)(0, nullptr, &n);
             if (err != CL_SUCCESS) {
                 default_error_ = err;
                 return;
@@ -2731,7 +2742,7 @@ private:
             }
 
             vector<cl_platform_id> ids(n);
-            err = ::clGetPlatformIDs(n, ids.data(), nullptr);
+            err = CL_(clGetPlatformIDs)(n, ids.data(), nullptr);
             if (err != CL_SUCCESS) {
                 default_error_ = err;
                 return;
@@ -2821,7 +2832,7 @@ public:
     cl_int getInfo(cl_platform_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetPlatformInfo, object_, name, param),
+            detail::getInfo(CL_(clGetPlatformInfo), object_, name, param),
             __GET_PLATFORM_INFO_ERR);
     }
 
@@ -2851,14 +2862,14 @@ public:
         if( devices == nullptr ) {
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
-        cl_int err = ::clGetDeviceIDs(object_, type, 0, nullptr, &n);
+        cl_int err = CL_(clGetDeviceIDs)(object_, type, 0, nullptr, &n);
         if (err != CL_SUCCESS  && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
         }
 
         vector<cl_device_id> ids(n);
         if (n>0) {
-            err = ::clGetDeviceIDs(object_, type, n, ids.data(), nullptr);
+            err = CL_(clGetDeviceIDs)(object_, type, n, ids.data(), nullptr);
             if (err != CL_SUCCESS) {
                 return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
             }
@@ -2987,13 +2998,13 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
         }
 
-        cl_int err = ::clGetPlatformIDs(0, nullptr, &n);
+        cl_int err = CL_(clGetPlatformIDs)(0, nullptr, &n);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
         }
 
         vector<cl_platform_id> ids(n);
-        err = ::clGetPlatformIDs(n, ids.data(), nullptr);
+        err = CL_(clGetPlatformIDs)(n, ids.data(), nullptr);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
         }
@@ -3048,7 +3059,7 @@ public:
     cl_int
     unloadCompiler()
     {
-        return ::clUnloadPlatformCompiler(object_);
+        return CL_(clUnloadPlatformCompiler)(object_);
     }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 }; // class Platform
@@ -3059,14 +3070,14 @@ inline cl_int Device::createSubDevices(const cl_device_partition_property* prope
                          vector<Device>* devices)
 {
     cl_uint n = 0;
-    cl_int err = clCreateSubDevices(object_, properties, 0, nullptr, &n);
+    cl_int err = CL_(clCreateSubDevices)(object_, properties, 0, nullptr, &n);
     if (err != CL_SUCCESS)
     {
         return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
     }
 
     vector<cl_device_id> ids(n);
-    err = clCreateSubDevices(object_, properties, n, ids.data(), nullptr);
+    err = CL_(clCreateSubDevices)(object_, properties, n, ids.data(), nullptr);
     if (err != CL_SUCCESS)
     {
         return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
@@ -3158,7 +3169,7 @@ UnloadCompiler() CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 inline cl_int
 UnloadCompiler()
 {
-    return ::clUnloadCompiler();
+    return CL_(clUnloadCompiler)();
 }
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
@@ -3326,7 +3337,7 @@ public:
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
 
-        object_ = ::clCreateContext(
+        object_ = CL_(clCreateContext)(
             properties, (cl_uint) numDevices,
             deviceIDs.data(),
             notifyFptr, data, &error);
@@ -3356,7 +3367,7 @@ public:
 
         cl_device_id deviceID = device();
 
-        object_ = ::clCreateContext(
+        object_ = CL_(clCreateContext)(
             properties, 1,
             &deviceID,
             notifyFptr, data, &error);
@@ -3445,7 +3456,7 @@ public:
             properties = &prop[0];
         }
 #endif
-        object_ = ::clCreateContextFromType(
+        object_ = CL_(clCreateContextFromType)(
             properties, type, notifyFptr, data, &error);
 
         detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
@@ -3510,7 +3521,7 @@ public:
     cl_int getInfo(cl_context_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetContextInfo, object_, name, param),
+            detail::getInfo(CL_(clGetContextInfo), object_, name, param),
             __GET_CONTEXT_INFO_ERR);
     }
 
@@ -3543,7 +3554,7 @@ public:
             return CL_SUCCESS;
         }
 
-        cl_int err = ::clGetSupportedImageFormats(
+        cl_int err = CL_(clGetSupportedImageFormats)(
            object_, 
            flags,
            type, 
@@ -3556,7 +3567,7 @@ public:
 
         if (numEntries > 0) {
             vector<ImageFormat> value(numEntries);
-            err = ::clGetSupportedImageFormats(
+            err = CL_(clGetSupportedImageFormats)(
                 object_,
                 flags,
                 type,
@@ -3628,7 +3639,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetContextDestructorCallback(
+            CL_(clSetContextDestructorCallback)(
                 object_,
                 pfn_notify,
                 user_data),
@@ -3711,7 +3722,7 @@ public:
     cl_int getInfo(cl_event_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetEventInfo, object_, name, param),
+            detail::getInfo(CL_(clGetEventInfo), object_, name, param),
             __GET_EVENT_INFO_ERR);
     }
 
@@ -3734,7 +3745,7 @@ public:
     cl_int getProfilingInfo(cl_profiling_info name, T* param) const
     {
         return detail::errHandler(detail::getInfo(
-            &::clGetEventProfilingInfo, object_, name, param),
+            CL_(clGetEventProfilingInfo), object_, name, param),
             __GET_EVENT_PROFILE_INFO_ERR);
     }
 
@@ -3759,7 +3770,7 @@ public:
     cl_int wait() const
     {
         return detail::errHandler(
-            ::clWaitForEvents(1, &object_),
+            CL_(clWaitForEvents)(1, &object_),
             __WAIT_FOR_EVENTS_ERR);
     }
 
@@ -3774,7 +3785,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetEventCallback(
+            CL_(clSetEventCallback)(
                 object_,
                 type,
                 pfn_notify,
@@ -3794,7 +3805,7 @@ public:
         "Size of cl::Event must be equal to size of cl_event");
 
         return detail::errHandler(
-            ::clWaitForEvents(
+            CL_(clWaitForEvents)(
                 (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : nullptr),
             __WAIT_FOR_EVENTS_ERR);
     }
@@ -3817,7 +3828,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateUserEvent(
+        object_ = CL_(clCreateUserEvent)(
             context(),
             &error);
 
@@ -3837,7 +3848,7 @@ public:
     cl_int setStatus(cl_int status)
     {
         return detail::errHandler(
-            ::clSetUserEventStatus(object_,status), 
+            CL_(clSetUserEventStatus)(object_,status), 
             __SET_USER_EVENT_STATUS_ERR);
     }
 };
@@ -3851,7 +3862,7 @@ inline static cl_int
 WaitForEvents(const vector<Event>& events)
 {
     return detail::errHandler(
-        ::clWaitForEvents(
+        CL_(clWaitForEvents)(
             (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : nullptr),
         __WAIT_FOR_EVENTS_ERR);
 }
@@ -3900,7 +3911,7 @@ public:
     cl_int getInfo(cl_mem_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetMemObjectInfo, object_, name, param),
+            detail::getInfo(CL_(clGetMemObjectInfo), object_, name, param),
             __GET_MEM_OBJECT_INFO_ERR);
     }
 
@@ -3937,7 +3948,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetMemObjectDestructorCallback(
+            CL_(clSetMemObjectDestructorCallback)(
                 object_,
                 pfn_notify,
                 user_data), 
@@ -4132,7 +4143,7 @@ public:
     {
         // Allocate memory with default alignment matching the size of the type
         void* voidPointer =
-            clSVMAlloc(
+            CL_(clSVMAlloc)(
             context_(),
             SVMTrait::getSVMMemFlags(),
             size*sizeof(T),
@@ -4150,7 +4161,7 @@ public:
         if (map && !(SVMTrait::getSVMMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
             cl_int err = enqueueMapSVM(retValue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, size*sizeof(T));
             if (err != CL_SUCCESS) {
-                clSVMFree(context_(), retValue);
+                CL_(clSVMFree)(context_(), retValue);
                 retValue = nullptr;
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
                 std::bad_alloc excep;
@@ -4165,7 +4176,7 @@ public:
 
     void deallocate(pointer p, size_type)
     {
-        clSVMFree(context_(), p);
+        CL_(clSVMFree)(context_(), p);
     }
 
     /**
@@ -4359,7 +4370,7 @@ public:
         cl_int* err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, host_ptr, &error);
 
         detail::errHandler(error, __CREATE_BUFFER_ERR);
         if (err != nullptr) {
@@ -4389,11 +4400,11 @@ public:
         cl_int error;
 
         if (properties.empty()) {
-            object_ = ::clCreateBufferWithProperties(context(), nullptr, flags,
+            object_ = CL_(clCreateBufferWithProperties)(context(), nullptr, flags,
                                                      size, host_ptr, &error);
         }
         else {
-            object_ = ::clCreateBufferWithProperties(
+            object_ = CL_(clCreateBufferWithProperties)(
                 context(), properties.data(), flags, size, host_ptr, &error);
         }
 
@@ -4472,9 +4483,9 @@ public:
         Context context = Context::getDefault(err);
 
         if( useHostPtr ) {
-            object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+            object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
         } else {
-            object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+            object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
         }
 
         detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -4545,7 +4556,7 @@ public:
     {
         Buffer result;
         cl_int error;
-        result.object_ = ::clCreateSubBuffer(
+        result.object_ = CL_(clCreateSubBuffer)(
             object_, 
             flags, 
             buffer_create_type, 
@@ -4667,7 +4678,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLBuffer(
+        object_ = CL_(clCreateFromGLBuffer)(
             context(),
             flags,
             bufobj,
@@ -4709,7 +4720,7 @@ public:
         cl_GLuint * gl_object_name)
     {
         return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
+            CL_(clGetGLObjectInfo)(object_,type,gl_object_name),
             __GET_GL_OBJECT_INFO_ERR);
     }
 };
@@ -4737,7 +4748,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLRenderbuffer(
+        object_ = CL_(clCreateFromGLRenderbuffer)(
             context(),
             flags,
             bufobj,
@@ -4779,7 +4790,7 @@ public:
         cl_GLuint * gl_object_name)
     {
         return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
+            CL_(clGetGLObjectInfo)(object_,type,gl_object_name),
             __GET_GL_OBJECT_INFO_ERR);
     }
 };
@@ -4823,7 +4834,7 @@ public:
     cl_int getImageInfo(cl_image_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetImageInfo, object_, name, param),
+            detail::getInfo(CL_(clGetImageInfo), object_, name, param),
             __GET_IMAGE_INFO_ERR);
     }
     
@@ -4870,7 +4881,7 @@ public:
         desc.image_type = CL_MEM_OBJECT_IMAGE1D;
         desc.image_width = width;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -4908,11 +4919,11 @@ public:
       desc.image_width = width;
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, host_ptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, host_ptr, &error);
       }
 
@@ -4967,7 +4978,7 @@ public:
         desc.image_width = width;
         desc.buffer = buffer();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -5005,11 +5016,11 @@ public:
       desc.buffer = buffer();
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, nullptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, nullptr, &error);
       }
 
@@ -5061,7 +5072,7 @@ public:
         desc.image_array_size = arraySize;
         desc.image_row_pitch = rowPitch;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -5102,11 +5113,11 @@ public:
       desc.image_row_pitch = rowPitch;
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, host_ptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, host_ptr, &error);
       }
 
@@ -5186,7 +5197,7 @@ public:
             desc.image_height = height;
             desc.image_row_pitch = row_pitch;
 
-            object_ = ::clCreateImage(
+            object_ = CL_(clCreateImage)(
                 context(),
                 flags,
                 &format,
@@ -5203,7 +5214,7 @@ public:
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
         if (!useCreateImage)
         {
-            object_ = ::clCreateImage2D(
+            object_ = CL_(clCreateImage2D)(
                 context(), flags,&format, width, height, row_pitch, host_ptr, &error);
 
             detail::errHandler(error, __CREATE_IMAGE2D_ERR);
@@ -5241,7 +5252,7 @@ public:
         desc.image_row_pitch = row_pitch;
         desc.buffer = sourceBuffer();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(),
             0, // flags inherited from buffer
             &format,
@@ -5304,7 +5315,7 @@ public:
         desc.num_samples = sourceNumSamples;
         desc.buffer = sourceImage();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(),
             0, // flags should be inherited from mem_object
             &sourceFormat,
@@ -5343,11 +5354,11 @@ public:
       desc.image_row_pitch = row_pitch;
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, host_ptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, host_ptr, &error);
       }
 
@@ -5380,11 +5391,11 @@ public:
       desc.buffer = buffer();
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, nullptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, nullptr, &error);
       }
 
@@ -5448,7 +5459,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture2D(
+        object_ = CL_(clCreateFromGLTexture2D)(
             context(),
             flags,
             target,
@@ -5520,7 +5531,7 @@ public:
         desc.image_row_pitch = rowPitch;
         desc.image_slice_pitch = slicePitch;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -5562,11 +5573,11 @@ public:
       desc.image_slice_pitch = slicePitch;
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, host_ptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, host_ptr, &error);
       }
 
@@ -5648,7 +5659,7 @@ public:
             desc.image_row_pitch = row_pitch;
             desc.image_slice_pitch = slice_pitch;
 
-            object_ = ::clCreateImage(
+            object_ = CL_(clCreateImage)(
                 context(), 
                 flags, 
                 &format, 
@@ -5665,7 +5676,7 @@ public:
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
         if (!useCreateImage)
         {
-            object_ = ::clCreateImage3D(
+            object_ = CL_(clCreateImage3D)(
                 context(), flags, &format, width, height, depth, row_pitch,
                 slice_pitch, host_ptr, &error);
 
@@ -5704,11 +5715,11 @@ public:
       desc.image_slice_pitch = slice_pitch;
 
       if (properties.empty()) {
-        object_ = ::clCreateImageWithProperties(
+        object_ = CL_(clCreateImageWithProperties)(
             context(), nullptr, flags, &format, &desc, host_ptr, &error);
       } else {
         object_ =
-            ::clCreateImageWithProperties(context(), properties.data(), flags,
+            CL_(clCreateImageWithProperties)(context(), properties.data(), flags,
                                           &format, &desc, host_ptr, &error);
       }
 
@@ -5770,7 +5781,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture3D(
+        object_ = CL_(clCreateFromGLTexture3D)(
             context(),
             flags,
             target,
@@ -5829,7 +5840,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture(
+        object_ = CL_(clCreateFromGLTexture)(
             context(), 
             flags, 
             target,
@@ -5895,7 +5906,7 @@ public:
         cl_int error;
 
         cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+        object_ = CL_(clCreatePipe)(context(), flags, packet_size, max_packets, nullptr, &error);
 
         detail::errHandler(error, __CREATE_PIPE_ERR);
         if (err != nullptr) {
@@ -5921,7 +5932,7 @@ public:
         Context context = Context::getDefault(err);
 
         cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+        object_ = CL_(clCreatePipe)(context(), flags, packet_size, max_packets, nullptr, &error);
 
         detail::errHandler(error, __CREATE_PIPE_ERR);
         if (err != nullptr) {
@@ -5959,7 +5970,7 @@ public:
     cl_int getInfo(cl_pipe_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetPipeInfo, object_, name, param),
+            detail::getInfo(CL_(clGetPipeInfo), object_, name, param),
             __GET_PIPE_INFO_ERR);
     }
 
@@ -6013,7 +6024,7 @@ public:
             CL_SAMPLER_ADDRESSING_MODE, addressing_mode,
             CL_SAMPLER_FILTER_MODE, filter_mode,
             0 };
-        object_ = ::clCreateSamplerWithProperties(
+        object_ = CL_(clCreateSamplerWithProperties)(
             context(),
             sampler_properties,
             &error);
@@ -6023,7 +6034,7 @@ public:
             *err = error;
         }
 #else
-        object_ = ::clCreateSampler(
+        object_ = CL_(clCreateSampler)(
             context(),
             normalized_coords,
             addressing_mode,
@@ -6066,7 +6077,7 @@ public:
     cl_int getInfo(cl_sampler_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetSamplerInfo, object_, name, param),
+            detail::getInfo(CL_(clGetSamplerInfo), object_, name, param),
             __GET_SAMPLER_INFO_ERR);
     }
 
@@ -6275,7 +6286,7 @@ public:
     cl_int getInfo(cl_kernel_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetKernelInfo, object_, name, param),
+            detail::getInfo(CL_(clGetKernelInfo), object_, name, param),
             __GET_KERNEL_INFO_ERR);
     }
 
@@ -6297,7 +6308,7 @@ public:
     cl_int getArgInfo(cl_uint argIndex, cl_kernel_arg_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetKernelArgInfo, object_, argIndex, name, param),
+            detail::getInfo(CL_(clGetKernelArgInfo), object_, argIndex, name, param),
             __GET_KERNEL_ARG_INFO_ERR);
     }
 
@@ -6321,7 +6332,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetKernelWorkGroupInfo, object_, device(), name, param),
+                CL_(clGetKernelWorkGroupInfo), object_, device(), name, param),
                 __GET_KERNEL_WORK_GROUP_INFO_ERR);
     }
 
@@ -6344,7 +6355,7 @@ public:
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
         return detail::errHandler(
-            clGetKernelSubGroupInfo(object_, dev(), name, range.size(), range.get(), sizeof(size_type), param, nullptr),
+            CL_(clGetKernelSubGroupInfo)(object_, dev(), name, range.size(), range.get(), sizeof(size_type), param, nullptr),
             __GET_KERNEL_SUB_GROUP_INFO_ERR);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6379,7 +6390,7 @@ public:
     cl_int setArg(cl_uint index, const cl::pointer<T, D> &argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.get()),
+            CL_(clSetKernelArgSVMPointer)(object_, index, argPtr.get()),
             __SET_KERNEL_ARGS_ERR);
     }
 
@@ -6389,7 +6400,7 @@ public:
     cl_int setArg(cl_uint index, const cl::vector<T, Alloc> &argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.data()),
+            CL_(clSetKernelArgSVMPointer)(object_, index, argPtr.data()),
             __SET_KERNEL_ARGS_ERR);
     }
 
@@ -6400,7 +6411,7 @@ public:
         setArg(cl_uint index, const T argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr),
+            CL_(clSetKernelArgSVMPointer)(object_, index, argPtr),
             __SET_KERNEL_ARGS_ERR);
     }
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
@@ -6412,7 +6423,7 @@ public:
         setArg(cl_uint index, const T &value)
     {
         return detail::errHandler(
-            ::clSetKernelArg(
+            CL_(clSetKernelArg)(
                 object_,
                 index,
                 detail::KernelArgumentHandler<T>::size(value),
@@ -6423,7 +6434,7 @@ public:
     cl_int setArg(cl_uint index, size_type size, const void* argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArg(object_, index, size, argPtr),
+            CL_(clSetKernelArg)(object_, index, size, argPtr),
             __SET_KERNEL_ARGS_ERR);
     }
 
@@ -6435,7 +6446,7 @@ public:
     cl_int setSVMPointers(const vector<void*> &pointerList)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_PTRS,
                 sizeof(void*)*pointerList.size(),
@@ -6450,7 +6461,7 @@ public:
     cl_int setSVMPointers(const std::array<void*, ArrayLength> &pointerList)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_PTRS,
                 sizeof(void*)*pointerList.size(),
@@ -6472,7 +6483,7 @@ public:
     {
         cl_bool svmEnabled_ = svmEnabled ? CL_TRUE : CL_FALSE;
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
                 sizeof(cl_bool),
@@ -6517,7 +6528,7 @@ public:
 
         setSVMPointersHelper<0, 1 + sizeof...(Ts)>(pointerList, t0, ts...);
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
             object_,
             CL_KERNEL_EXEC_INFO_SVM_PTRS,
             sizeof(void*)*(1 + sizeof...(Ts)),
@@ -6528,7 +6539,7 @@ public:
     cl_int setExecInfo(cl_kernel_exec_info param_name, const T& val)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
             object_,
             param_name,
             sizeof(T),
@@ -6551,7 +6562,7 @@ public:
     Kernel clone()
     {
         cl_int error;
-        Kernel retValue(clCloneKernel(this->get(), &error));
+        Kernel retValue(CL_(clCloneKernel)(this->get(), &error));
 
         detail::errHandler(error, __CLONE_KERNEL_ERR);
         return retValue;
@@ -6585,14 +6596,14 @@ public:
 
         Context context = Context::getDefault(err);
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)1, &strings, &length, &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
         if (error == CL_SUCCESS && build) {
 
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6623,13 +6634,13 @@ public:
         const char * strings = source.c_str();
         const size_type length  = source.size();
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)1, &strings, &length, &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
         if (error == CL_SUCCESS && build) {
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6675,7 +6686,7 @@ public:
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
         }
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)n, strings.data(), lengths.data(), &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
@@ -6710,7 +6721,7 @@ public:
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
         }
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)n, strings.data(), lengths.data(), &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
@@ -6736,7 +6747,7 @@ public:
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
-        object_ = ::clCreateProgramWithIL(
+        object_ = CL_(clCreateProgramWithIL)(
             context(), static_cast<const void*>(IL.data()), IL.size(), &error);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6754,7 +6765,7 @@ public:
 
         if (error == CL_SUCCESS && build) {
 
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6790,7 +6801,7 @@ public:
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
-        object_ = ::clCreateProgramWithIL(
+        object_ = CL_(clCreateProgramWithIL)(
             context(), static_cast<const void*>(IL.data()), IL.size(), &error);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6807,7 +6818,7 @@ public:
         detail::errHandler(error, __CREATE_PROGRAM_WITH_IL_ERR);
 
         if (error == CL_SUCCESS && build) {
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6891,7 +6902,7 @@ public:
             binaryStatus->resize(numDevices);
         }
 
-        object_ = ::clCreateProgramWithBinary(
+        object_ = CL_(clCreateProgramWithBinary)(
             context(), (cl_uint) devices.size(),
             deviceIDs.data(),
             lengths.data(), images.data(), (binaryStatus != nullptr && numDevices > 0)
@@ -6925,7 +6936,7 @@ public:
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
         
-        object_ = ::clCreateProgramWithBuiltInKernels(
+        object_ = CL_(clCreateProgramWithBuiltInKernels)(
             context(), 
             (cl_uint) devices.size(),
             deviceIDs.data(),
@@ -6979,7 +6990,7 @@ public:
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
 
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
             (cl_uint)
             devices.size(),
@@ -7008,7 +7019,7 @@ public:
     {
         cl_device_id deviceID = device();
 
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
             1,
             &deviceID,
@@ -7034,7 +7045,7 @@ public:
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
             0,
             nullptr,
@@ -7059,7 +7070,7 @@ public:
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
-        cl_int error = ::clCompileProgram(
+        cl_int error = CL_(clCompileProgram)(
             object_,
             0,
             nullptr,
@@ -7095,7 +7106,7 @@ public:
         for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
         }
-        cl_int error = ::clCompileProgram(
+        cl_int error = CL_(clCompileProgram)(
             object_,
             0,
             nullptr,
@@ -7137,7 +7148,7 @@ public:
         for(const Device& device: deviceList) {
             deviceIDList.push_back(device());
         }
-        cl_int error = ::clCompileProgram(
+        cl_int error = CL_(clCompileProgram)(
             object_,
             static_cast<cl_uint>(deviceList.size()),
             reinterpret_cast<const cl_device_id*>(deviceIDList.data()),
@@ -7155,7 +7166,7 @@ public:
     cl_int getInfo(cl_program_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
+            detail::getInfo(CL_(clGetProgramInfo), object_, name, param),
             __GET_PROGRAM_INFO_ERR);
     }
 
@@ -7178,7 +7189,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetProgramBuildInfo, object_, device(), name, param),
+                CL_(clGetProgramBuildInfo), object_, device(), name, param),
                 __GET_PROGRAM_BUILD_INFO_ERR);
     }
 
@@ -7242,14 +7253,14 @@ public:
     cl_int createKernels(vector<Kernel>* kernels)
     {
         cl_uint numKernels;
-        cl_int err = ::clCreateKernelsInProgram(object_, 0, nullptr, &numKernels);
+        cl_int err = CL_(clCreateKernelsInProgram)(object_, 0, nullptr, &numKernels);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
         }
 
         vector<cl_kernel> value(numKernels);
         
-        err = ::clCreateKernelsInProgram(
+        err = CL_(clCreateKernelsInProgram)(
             object_, numKernels, value.data(), nullptr);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
@@ -7286,7 +7297,7 @@ public:
         void * user_data = nullptr) CL_API_SUFFIX__VERSION_2_2_DEPRECATED
     {
         return detail::errHandler(
-            ::clSetProgramReleaseCallback(
+            CL_(clSetProgramReleaseCallback)(
                 object_,
                 pfn_notify,
                 user_data),
@@ -7303,7 +7314,7 @@ public:
         setSpecializationConstant(cl_uint index, const T &value)
     {
         return detail::errHandler(
-            ::clSetProgramSpecializationConstant(
+            CL_(clSetProgramSpecializationConstant)(
                 object_,
                 index,
                 sizeof(value),
@@ -7318,7 +7329,7 @@ public:
     cl_int setSpecializationConstant(cl_uint index, size_type size, const void* value)
     {
         return detail::errHandler(
-            ::clSetProgramSpecializationConstant(
+            CL_(clSetProgramSpecializationConstant)(
                 object_,
                 index,
                 size,
@@ -7345,7 +7356,7 @@ inline Program linkProgram(
         detail::errHandler(error_local, __LINK_PROGRAM_ERR);
     }
 
-    cl_program prog = ::clLinkProgram(
+    cl_program prog = CL_(clLinkProgram)(
         ctx(),
         0,
         nullptr,
@@ -7395,7 +7406,7 @@ inline Program linkProgram(
         }
     }
 
-    cl_program prog = ::clLinkProgram(
+    cl_program prog = CL_(clLinkProgram)(
         ctx(),
         0,
         nullptr,
@@ -7446,7 +7457,7 @@ inline cl_int cl::Program::getInfo(cl_program_info name, vector<vector<unsigned 
         }
 
         return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
+            detail::getInfo(CL_(clGetProgramInfo), object_, name, param),
             __GET_PROGRAM_INFO_ERR);
     }
 
@@ -7472,7 +7483,7 @@ inline cl_int cl::Program::setSpecializationConstant(cl_uint index, const bool &
 {
     cl_uchar ucValue = value ? CL_UCHAR_MAX : 0;
     return detail::errHandler(
-        ::clSetProgramSpecializationConstant(
+        CL_(clSetProgramSpecializationConstant)(
             object_,
             index,
             sizeof(ucValue),
@@ -7485,7 +7496,7 @@ inline Kernel::Kernel(const Program& program, const string& name, cl_int* err)
 {
     cl_int error;
 
-    object_ = ::clCreateKernel(program(), name.c_str(), &error);
+    object_ = CL_(clCreateKernel)(program(), name.c_str(), &error);
     detail::errHandler(error, __CREATE_KERNEL_ERR);
 
     if (err != nullptr) {
@@ -7497,7 +7508,7 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 {
     cl_int error;
 
-    object_ = ::clCreateKernel(program(), name, &error);
+    object_ = CL_(clCreateKernel)(program(), name, &error);
     detail::errHandler(error, __CREATE_KERNEL_ERR);
 
     if (err != nullptr) {
@@ -7661,7 +7672,7 @@ public:
                 cl_queue_properties queue_properties[] = {
                     CL_QUEUE_PROPERTIES, properties, 0 };
                 if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-                    object_ = ::clCreateCommandQueueWithProperties(
+                    object_ = CL_(clCreateCommandQueueWithProperties)(
                         context(), device(), queue_properties, &error);
                 }
                 else {
@@ -7676,7 +7687,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
             if (!useWithProperties) {
-                object_ = ::clCreateCommandQueue(
+                object_ = CL_(clCreateCommandQueue)(
                     context(), device(), properties, &error);
 
                 detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7727,7 +7738,7 @@ public:
                cl_queue_properties queue_properties[] = {
                    CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
 
-               object_ = ::clCreateCommandQueueWithProperties(
+               object_ = CL_(clCreateCommandQueueWithProperties)(
                    context(), device(), queue_properties, &error);
 
                detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7738,7 +7749,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
            if (!useWithProperties) {
-               object_ = ::clCreateCommandQueue(
+               object_ = CL_(clCreateCommandQueue)(
                    context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
 
                detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7792,7 +7803,7 @@ public:
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, properties, 0 };
             if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-                object_ = ::clCreateCommandQueueWithProperties(
+                object_ = CL_(clCreateCommandQueueWithProperties)(
                     context(), devices[0](), queue_properties, &error);
             }
             else {
@@ -7807,7 +7818,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), devices[0](), properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7858,7 +7869,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), devices[0](), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7869,7 +7880,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), devices[0](), static_cast<cl_command_queue_properties>(properties), &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7909,7 +7920,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, properties, 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7920,7 +7931,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), device(), properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7960,7 +7971,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7971,7 +7982,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -8033,7 +8044,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetCommandQueueInfo, object_, name, param),
+                CL_(clGetCommandQueueInfo), object_, name, param),
                 __GET_COMMAND_QUEUE_INFO_ERR);
     }
 
@@ -8061,7 +8072,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadBuffer(
+            CL_(clEnqueueReadBuffer)(
                 object_, buffer(), blocking, offset, size,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8086,7 +8097,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteBuffer(
+            CL_(clEnqueueWriteBuffer)(
                 object_, buffer(), blocking, offset, size,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8111,7 +8122,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBuffer(
+            CL_(clEnqueueCopyBuffer)(
                 object_, src(), dst(), src_offset, dst_offset, size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -8140,7 +8151,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadBufferRect(
+            CL_(clEnqueueReadBufferRect)(
                 object_, 
                 buffer(), 
                 blocking,
@@ -8208,7 +8219,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteBufferRect(
+            CL_(clEnqueueWriteBufferRect)(
                 object_, 
                 buffer(), 
                 blocking,
@@ -8275,7 +8286,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferRect(
+            CL_(clEnqueueCopyBufferRect)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8348,7 +8359,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueFillBuffer(
+            CL_(clEnqueueFillBuffer)(
                 object_, 
                 buffer(),
                 static_cast<void*>(&pattern),
@@ -8380,7 +8391,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadImage(
+            CL_(clEnqueueReadImage)(
                 object_, 
                 image(), 
                 blocking, 
@@ -8436,7 +8447,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteImage(
+            CL_(clEnqueueWriteImage)(
                 object_, 
                 image(), 
                 blocking, 
@@ -8490,7 +8501,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyImage(
+            CL_(clEnqueueCopyImage)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8550,7 +8561,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
+            CL_(clEnqueueFillImage)(
                 object_,
                 image(),
                 static_cast<void*>(&fillColor),
@@ -8607,7 +8618,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyImageToBuffer(
+            CL_(clEnqueueCopyImageToBuffer)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8655,7 +8666,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferToImage(
+            CL_(clEnqueueCopyBufferToImage)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8704,7 +8715,7 @@ public:
     {
         cl_event tmp;
         cl_int error;
-        void * result = ::clEnqueueMapBuffer(
+        void * result = CL_(clEnqueueMapBuffer)(
             object_, buffer(), blocking, flags, offset, size,
             (events != nullptr) ? (cl_uint) events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -8735,7 +8746,7 @@ public:
     {
         cl_event tmp;
         cl_int error;
-        void * result = ::clEnqueueMapImage(
+        void * result = CL_(clEnqueueMapImage)(
             object_, image(), blocking, flags,
             origin.data(), 
             region.data(),
@@ -8787,7 +8798,7 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
                 object_, blocking, static_cast<void *>(dst_ptr), static_cast<const void *>(src_ptr), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
@@ -8812,7 +8823,7 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
                 object_, blocking, static_cast<void *>(dst_ptr.get()), static_cast<const void *>(src_ptr.get()),
                 size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8840,7 +8851,7 @@ public:
         if(src_container.size() != dst_container.size()){
             return detail::errHandler(CL_INVALID_VALUE,__ENQUEUE_COPY_SVM_ERR);
         }
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
                 object_, blocking, static_cast<void *>(dst_container.data()),
                 static_cast<const void *>(src_container.data()),
                 dst_container.size() * sizeof(T),
@@ -8866,7 +8877,7 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
                 object_, static_cast<void *>(ptr), static_cast<void *>(&pattern),
                 sizeof(PatternType), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8891,7 +8902,7 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
                 object_, static_cast<void *>(ptr.get()), static_cast<void *>(&pattern),
                 sizeof(PatternType), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8916,7 +8927,7 @@ public:
             Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
                 object_, static_cast<void *>(container.data()), static_cast<void *>(&pattern),
                 sizeof(PatternType), container.size() * sizeof(T),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
@@ -8943,7 +8954,7 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
             object_, blocking, flags, static_cast<void*>(ptr), size,
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -8971,7 +8982,7 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
             object_, blocking, flags, static_cast<void*>(ptr.get()), size,
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -8997,7 +9008,7 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
             object_, blocking, flags, static_cast<void*>(container.data()), container.size()*sizeof(T),
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -9019,7 +9030,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueUnmapMemObject(
+            CL_(clEnqueueUnmapMemObject)(
                 object_, memory(), mapped_ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -9046,7 +9057,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
+            CL_(clEnqueueSVMUnmap)(
             object_, static_cast<void*>(ptr),
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -9071,7 +9082,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
+            CL_(clEnqueueSVMUnmap)(
             object_, static_cast<void*>(ptr.get()),
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -9096,7 +9107,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
+            CL_(clEnqueueSVMUnmap)(
             object_, static_cast<void*>(container.data()),
             (events != nullptr) ? (cl_uint)events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -9128,7 +9139,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueMarkerWithWaitList(
+            CL_(clEnqueueMarkerWithWaitList)(
                 object_,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -9158,7 +9169,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueBarrierWithWaitList(
+            CL_(clEnqueueBarrierWithWaitList)(
                 object_,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -9191,7 +9202,7 @@ public:
         }
         
         cl_int err = detail::errHandler(
-            ::clEnqueueMigrateMemObjects(
+            CL_(clEnqueueMigrateMemObjects)(
                 object_, 
                 (cl_uint)memObjects.size(), 
                 localMemObjects.data(),
@@ -9224,7 +9235,7 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMigrateMem(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMigrateMem)(
             object_,
             svmRawPointers.size(), static_cast<void**>(svmRawPointers.data()),
             sizes.data(), // array of sizes not passed
@@ -9340,7 +9351,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueNDRangeKernel(
+            CL_(clEnqueueNDRangeKernel)(
                 object_, kernel(), (cl_uint) global.dimensions(),
                 offset.dimensions() != 0 ? (const size_type*) offset : nullptr,
                 (const size_type*) global,
@@ -9364,7 +9375,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueTask(
+            CL_(clEnqueueTask)(
                 object_, kernel(),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -9388,7 +9399,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueNativeKernel(
+            CL_(clEnqueueNativeKernel)(
                 object_, userFptr, args.first, args.second,
                 (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                 (mem_objects->size() > 0 ) ? reinterpret_cast<const cl_mem *>(mem_objects->data()) : nullptr,
@@ -9413,7 +9424,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueMarker(
+            CL_(clEnqueueMarker)(
                 object_, 
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MARKER_ERR);
@@ -9428,7 +9439,7 @@ public:
     cl_int enqueueWaitForEvents(const vector<Event>& events) const CL_API_SUFFIX__VERSION_1_1_DEPRECATED
     {
         return detail::errHandler(
-            ::clEnqueueWaitForEvents(
+            CL_(clEnqueueWaitForEvents)(
                 object_,
                 (cl_uint) events.size(),
                 events.size() > 0 ? (const cl_event*) &events.front() : nullptr),
@@ -9443,7 +9454,7 @@ public:
      {
         cl_event tmp;
         cl_int err = detail::errHandler(
-             ::clEnqueueAcquireGLObjects(
+             CL_(clEnqueueAcquireGLObjects)(
                  object_,
                  (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                  (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
@@ -9465,7 +9476,7 @@ public:
      {
         cl_event tmp;
         cl_int err = detail::errHandler(
-             ::clEnqueueReleaseGLObjects(
+             CL_(clEnqueueReleaseGLObjects)(
                  object_,
                  (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                  (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
@@ -9565,19 +9576,19 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
     cl_int enqueueBarrier() const CL_API_SUFFIX__VERSION_1_1_DEPRECATED
     {
         return detail::errHandler(
-            ::clEnqueueBarrier(object_),
+            CL_(clEnqueueBarrier)(object_),
             __ENQUEUE_BARRIER_ERR);
     }
 #endif // CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
     cl_int flush() const
     {
-        return detail::errHandler(::clFlush(object_), __FLUSH_ERR);
+        return detail::errHandler(CL_(clFlush)(object_), __FLUSH_ERR);
     }
 
     cl_int finish() const
     {
-        return detail::errHandler(::clFinish(object_), __FINISH_ERR);
+        return detail::errHandler(CL_(clFinish)(object_), __FINISH_ERR);
     }
 
 #ifdef cl_khr_external_memory
@@ -9702,7 +9713,7 @@ public:
 
         cl_queue_properties queue_properties[] = {
             CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9726,7 +9737,7 @@ public:
             CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties>(properties);
         cl_queue_properties queue_properties[] = {
             CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9753,7 +9764,7 @@ public:
             CL_QUEUE_PROPERTIES, mergedProperties,
             CL_QUEUE_SIZE, queueSize, 
             0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9782,7 +9793,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-            &::clGetCommandQueueInfo, object_, name, param),
+            CL_(clGetCommandQueueInfo), object_, name, param),
             __GET_COMMAND_QUEUE_INFO_ERR);
     }
 
@@ -9818,7 +9829,7 @@ public:
             CL_QUEUE_PROPERTIES, properties,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9846,7 +9857,7 @@ public:
             CL_QUEUE_PROPERTIES, properties,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9875,7 +9886,7 @@ public:
             CL_QUEUE_SIZE, queueSize,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9898,7 +9909,7 @@ public:
     static DeviceCommandQueue updateDefault(const Context &context, const Device &device, const DeviceCommandQueue &default_queue, cl_int *err = nullptr)
     {
         cl_int error;
-        error = clSetDefaultDeviceCommandQueue(context.get(), device.get(), default_queue.get());
+        error = CL_(clSetDefaultDeviceCommandQueue)(context.get(), device.get(), default_queue.get());
 
         detail::errHandler(error, __SET_DEFAULT_DEVICE_COMMAND_QUEUE_ERR);
         if (err != nullptr) {
@@ -9958,9 +9969,9 @@ Buffer::Buffer(
     size_type size = sizeof(DataType)*(endIterator - startIterator);
 
     if( useHostPtr ) {
-        object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
     } else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
     }
 
     detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -10011,10 +10022,10 @@ Buffer::Buffer(
     Context context = queue.getInfo<CL_QUEUE_CONTEXT>();
 
     if (useHostPtr) {
-        object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
     }
     else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
     }
 
     detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -10086,7 +10097,7 @@ inline void* enqueueMapBuffer(
         *err = error;
     }
 
-    void * result = ::clEnqueueMapBuffer(
+    void * result = CL_(clEnqueueMapBuffer)(
             queue(), buffer(), blocking, flags, offset, size,
             (events != nullptr) ? (cl_uint) events->size() : 0,
             (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
@@ -10190,7 +10201,7 @@ inline cl_int enqueueUnmapMemObject(
 
     cl_event tmp;
     cl_int err = detail::errHandler(
-        ::clEnqueueUnmapMemObject(
+        CL_(clEnqueueUnmapMemObject)(
         queue(), memory(), mapped_ptr,
         (events != nullptr) ? (cl_uint)events->size() : 0,
         (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
@@ -12192,6 +12203,8 @@ public:
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_
 
 #undef CL_HPP_DEFINE_STATIC_MEMBER_
+
+#undef CL_
 
 } // namespace cl
 


### PR DESCRIPTION
Add support for a macro `CL_HPP_OPENCL_API_WRAPPER` which will be used to wrap all OpenCL API calls.This can be used e.g. to load the OpenCL library dynamically with `dlopen()`/`dlsym()`.

This is similar to <https://github.com/KhronosGroup/OpenCL-CLHPP/pull/170>, but uses a macro which is called with the API function name instead of a namespace. This macro can e.g. call a function which will open the OpenCL library if needed, look up the function name and return a pointer to API function.