### PR TITLE
update minimum cmake version for strip_defines to 3.16

### DIFF
--- a/tests/strip_defines.cmake
+++ b/tests/strip_defines.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT INPUT OR NOT OUTPUT)
   message(FATAL_ERROR "Usage: cmake -D INPUT=<input> -D OUTPUT=<output> -P strip_defines.cmake")


### PR DESCRIPTION
This aligns with the rest of the repo, and is needed for newer cmake versions that no longer support very old cmake versions.