### PR TITLE
Add support for empty properties vector in commandNDRangeKernel

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -11930,7 +11930,7 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandNDRangeKernelKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
-                &properties[0],
+                properties.empty() ? nullptr : properties.data(),
                 kernel(),
                 (cl_uint) global.dimensions(),
                 offset.dimensions() != 0 ? (const size_type*) offset : nullptr,


### PR DESCRIPTION
In the C API, we pass properties in a 0 terminated array, or we can pass nullptr if we don't want any properties.

In the C++ bindings, properties are passed in a vector reference. This forces us to pass a vector containing 0 if we don't want properties, causing boilerplate. My change allows passing an empty vector, which would pass nullptr to the C API.