### PR TITLE
pass vectors by reference in getters

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -2924,14 +2924,7 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
 
-        // Cannot trivially assign because we need to capture intermediates
-        // with safe construction
-        // We must retain things we obtain from the API to avoid releasing
-        // API-owned objects.
-        if (devices) {
-            return getDevices(type, *devices);
-        }
-        return CL_SUCCESS;
+        return getDevices(type, *devices);
     }
 
 #if defined(CL_HPP_USE_DX_INTEROP)
@@ -3035,14 +3028,7 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
         }
 
-        // Cannot trivially assign because we need to capture intermediates
-        // with safe construction
-        // We must retain things we obtain from the API to avoid releasing
-        // API-owned objects.
-        if (devices) {
-            return getDevices(d3d_device_source, d3d_object, d3d_device_set, *devices);
-        }
-        return CL_SUCCESS;
+        return getDevices(d3d_device_source, d3d_object, d3d_device_set, *devices);
     }
 #endif
 
@@ -3086,10 +3072,7 @@ public:
             return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
         }
 
-        if (platforms) {
-            return get(*platforms);
-        }
-        return CL_SUCCESS;
+        return get(*platforms);
     }
 
     /*! \brief Gets the first available platform.


### PR DESCRIPTION
closes #331

I do not think, the `if(ptr)` checks do anything that is not covered by the `nullptr` check already, but I kept them, because they were there.
However, in my opinion, they should probably be removed, given, they return `CL_SUCCESS` on failure.

I only wrote overloads for the getters.
This pattern also appears on two other functions and seemingly on everything related to Events.
I did not want to introduce too much code at once.